### PR TITLE
Hyperthreading

### DIFF
--- a/lib/parallel.rb
+++ b/lib/parallel.rb
@@ -79,9 +79,7 @@ class Parallel
   def self.processor_count
     case RUBY_PLATFORM
     when /darwin/
-      physical_cpus = `hwprefs cpu_count`.to_i
-      hyperthreading = `hwprefs cpu_ht`.to_i == 1
-      hyperthreading ? physical_cpus * 2 : physical_cpus
+      `hwprefs thread_count`.to_i
     when /linux/
       `cat /proc/cpuinfo | grep processor | wc -l`.to_i
     when /freebsd/


### PR DESCRIPTION
Hi,
i noticed Parallel not using all possible "cores" on my box automatically after switching to Mac OS X. I changed the command to determine cpu count to `hwprefs thread_count`
Greetings, Mike
