### PR TITLE
Change thread_count back to cpu_count on Leopard (thread_count is not supported on Leopard)

### DIFF
--- a/lib/parallel.rb
+++ b/lib/parallel.rb
@@ -78,7 +78,9 @@ class Parallel
 
   def self.processor_count
     case RUBY_PLATFORM
-    when /darwin/
+    when /darwin9/
+      `hwprefs cpu_count`.to_i
+    when /darwin10/
       `hwprefs thread_count`.to_i
     when /linux/
       `cat /proc/cpuinfo | grep processor | wc -l`.to_i


### PR DESCRIPTION
Hi,

This is a small patch to continue to use cpu_count on Leopard, because thread_count is not supported. I didn't see specs to update for this functionality, but I may have missed them.

Thanks for the great tools,
Jeremy
