### PR TITLE
Count physical CPUs on OS X

### DIFF
--- a/lib/parallel.rb
+++ b/lib/parallel.rb
@@ -67,7 +67,7 @@ class Parallel
     when /darwin9/
       `hwprefs cpu_count`.to_i
     when /darwin/
-      (hwprefs_available? ? `hwprefs thread_count` : `sysctl -n hw.physicalcpu`).to_i
+      (hwprefs_available? ? `hwprefs thread_count` : sysctl_cpu_count).to_i
     when /linux/
       `grep -c processor /proc/cpuinfo`.to_i
     when /freebsd/
@@ -91,6 +91,15 @@ class Parallel
       results << (options[:with_index] ? yield(e,i) : yield(e))
     end
     results
+  end
+  
+  def self.sysctl_cpu_count
+    cpus = `sysctl -n hw.physicalcpu`
+    if cpus =~ /invalid/
+      # fall back to just cpu count
+      cpus = `sysctl -n hw.ncpu`
+    end
+    cpus
   end
 
   def self.hwprefs_available?

--- a/spec/parallel_spec.rb
+++ b/spec/parallel_spec.rb
@@ -12,10 +12,23 @@ describe Parallel do
       (1..999).should include(Parallel.processor_count)
     end
 
-    if RUBY_PLATFORM =~ /darwin10/
+    if RUBY_PLATFORM =~ /darwin/
       it 'works if hwprefs in not available' do
         Parallel.should_receive(:hwprefs_available?).and_return false
         (1..999).should include(Parallel.processor_count)
+      end
+      
+      it 'should return physical cpu count if possible' do
+        Parallel.should_receive(:hwprefs_available?).and_return false
+        Parallel.should_receive(:`).with('sysctl -n hw.physicalcpu').and_return '4'
+        Parallel.processor_count.should == 4
+      end
+      
+      it 'should return cpu count if physical cpu count is not possible' do
+        Parallel.should_receive(:hwprefs_available?).and_return false
+        Parallel.should_receive(:`).with('sysctl -n hw.physicalcpu').and_return 'second level name physicalcpu in hw.physicalcpu is invalid'
+        Parallel.should_receive(:`).with('sysctl -n hw.ncpu').and_return '1'
+        Parallel.processor_count.should == 1
       end
     end
 


### PR DESCRIPTION
I have an 2011 MacBook Pro with 8 CPUs, 4 physical and 4 virtual.  I use parallel through parallel_test, but I always have to pass `parallel:spec[4]` otherwise the virtual cores fight the physical cores and the tests take longer then not including the virtual cores at all.

Baseline (1 cpu, 174 tests): 47s
All cores (8 cpus, 174 tests): 23s
Physical only (4 cpus, 174 tests): 18s
