### PR TITLE
Update Readme with ProgressBar deprecation

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -77,7 +77,7 @@ gem install ruby-progressbar
 
 ```Ruby
 require 'ruby-progressbar'
-progress = ProgressBar.new("test", 100)
+progress = ProgressBar.create(:title => "The Progress", :total => 100)
 Parallel.map(1..100, :finish => lambda { |i, item| progress.increment }) { sleep 1 }
 ```
 


### PR DESCRIPTION
ProgressBar is deprecating #new in favour of #create.

While the options that I am passing are pretty much the defaults, I believe
that having them showcases the functionality of the progressbar gem.
