### PR TITLE
Correct number of CPU in KVM

### DIFF
--- a/lib/parallel.rb
+++ b/lib/parallel.rb
@@ -118,7 +118,7 @@ module Parallel
       when /darwin/
         (hwprefs_available? ? `hwprefs thread_count` : `sysctl -n hw.ncpu`).to_i
       when /linux|cygwin/
-        `grep -c processor /proc/cpuinfo`.to_i
+        `grep -c ^processor /proc/cpuinfo`.to_i
       when /(open|free)bsd/
         `sysctl -n hw.ncpu`.to_i
       when /mswin|mingw/


### PR DESCRIPTION
"grep -c processor /proc/cpuinfo" calculate number of processors correctly on physical hosts.

Problem appears on KVM guests as "processor" appears also in processor name and
"grep -c processor /proc/cpuinfo" return doubled number of CPUs, which is wrong

Usage of "grep -c ^processor /proc/cpuinfo" will count amount of cpus correctly on KVM, AWS and physical hosts.
