### PR TITLE
Processor count added for NetBSD

### DIFF
--- a/lib/parallel.rb
+++ b/lib/parallel.rb
@@ -119,7 +119,7 @@ module Parallel
         (hwprefs_available? ? `hwprefs thread_count` : `sysctl -n hw.ncpu`).to_i
       when /linux|cygwin/
         `grep -c ^processor /proc/cpuinfo`.to_i
-      when /(open|free)bsd/
+      when /(net|open|free)bsd/
         `sysctl -n hw.ncpu`.to_i
       when /mswin|mingw/
         require 'win32ole'


### PR DESCRIPTION
When trying Parallel on NetBSD: "Unknown architecture ( netbsd6.1 ) assuming one processor." Tried on two versions of NetBSD (5.1.2 and 6.1). The patched version seems to work fine now.

``` bash
$ uname -prs
NetBSD 5.1.2 i386
$ sysctl -n hw.ncpu
1
$ ruby --version
ruby 2.0.0p247 (2013-06-27 revision 41674) [i386-netbsdelf5.1.2]
$ ruby -e 'p `sysctl -n hw.ncpu`.to_i'
1

$ uname -prs
NetBSD 6.1 x86_64
$ sysctl -n hw.ncpu
1
$ ruby --version
ruby 2.0.0p247 (2013-06-27 revision 41674) [x86_64-netbsd6.1]
$ ruby -e 'p `sysctl -n hw.ncpu`.to_i'
1
```
