### PR TITLE
Fix uninitialized instance variable @to_be_killed

### DIFF
--- a/lib/parallel.rb
+++ b/lib/parallel.rb
@@ -308,7 +308,7 @@ module Parallel
 
     # kill all these pids or threads if user presses Ctrl+c
     def kill_on_ctrl_c(things)
-      if @to_be_killed
+      if defined?(@to_be_killed) && @to_be_killed
         @to_be_killed << things
       else
         @to_be_killed = [things]


### PR DESCRIPTION
Hi. Line 311 accesses instance variable @to_be_killed and it might not be initialized at this point. In that case, Ruby complains in verbose mode (`ruby -w`).
