### PR TITLE
FreeBSD sysctl does not include the "hw.physicalcpu" OID

### DIFF
--- a/lib/parallel.rb
+++ b/lib/parallel.rb
@@ -137,7 +137,7 @@ module Parallel
     def physical_processor_count
       @physical_processor_count ||= begin
         ppc = case RbConfig::CONFIG['host_os']
-        when /darwin1/, /freebsd/
+        when /darwin1/
           `sysctl -n hw.physicalcpu`.to_i
         when /linux/
           cores_per_physical = `grep cores /proc/cpuinfo`[/\d+/].to_i


### PR DESCRIPTION
FreeBSD does not seem to support "hw.physicalcpu", so it seems reasonable to remove it from Parallel.physical_processor_count(). Attempting to access it just raises an error on FreeBSD 9.

```
# uname -mor
FreeBSD 9.1-RELEASE amd64
# sysctl -n hw.physicalcpu
sysctl: unknown oid 'hw.physicalcpu'
```
