### PR TITLE
I think you meant to use the value of the database variable here

### DIFF
--- a/spec/cases/map_with_ar.rb
+++ b/spec/cases/map_with_ar.rb
@@ -3,7 +3,7 @@ require "active_record"
 
 Tempfile.open("xxx") do |f|
   database = "parallel_with_ar_test"
-  `mysql #{database} -e '' || mysql -e 'create database database'`
+  `mysql #{database} -e '' || mysql -e 'create database #{database}'`
 
   ActiveRecord::Schema.verbose = false
   ActiveRecord::Base.establish_connection(
@@ -30,6 +30,8 @@ Tempfile.open("xxx") do |f|
   Parallel.map(1..8) do |i|
     User.create!(:name => i)
   end
+
+  puts "User.count: #{User.count}"
 
   puts User.connection.reconnect!.inspect
 


### PR DESCRIPTION
I put a line to make sure it wasn't rolling back the changes like I had noticed and I figured the top line was supposed to read `create database parallel_with_ar_test` instead of `create database database`
