### PR TITLE
Replace string array literal with strings in IO.popen

### DIFF
--- a/lib/parallel.rb
+++ b/lib/parallel.rb
@@ -144,23 +144,23 @@ module Parallel
         elsif File.readable?("/proc/cpuinfo")
           IO.read("/proc/cpuinfo").scan(/^processor/).size
         elsif File.executable?("/usr/bin/hwprefs")
-          IO.popen(%w[/usr/bin/hwprefs thread_count]).read.to_i
+          IO.popen("/usr/bin/hwprefs thread_count").read.to_i
         elsif File.executable?("/usr/sbin/psrinfo")
           IO.popen("/usr/sbin/psrinfo").read.scan(/^.*on-*line/).size
         elsif File.executable?("/usr/sbin/ioscan")
-          IO.popen(%w[/usr/sbin/ioscan -kC processor]) do |out|
+          IO.popen("/usr/sbin/ioscan -kC processor") do |out|
             out.read.scan(/^.*processor/).size
           end
         elsif File.executable?("/usr/sbin/pmcycles")
-          IO.popen(%w[/usr/sbin/pmcycles -m]).read.count("\n")
+          IO.popen("/usr/sbin/pmcycles -m").read.count("\n")
         elsif File.executable?("/usr/sbin/lsdev")
-          IO.popen(%w[/usr/sbin/lsdev -Cc processor -S 1]).read.count("\n")
+          IO.popen("/usr/sbin/lsdev -Cc processor -S 1").read.count("\n")
         elsif File.executable?("/usr/sbin/sysconf") and os_name =~ /irix/i
-          IO.popen(%w[/usr/sbin/sysconf NPROC_ONLN]).read.to_i
+          IO.popen("/usr/sbin/sysconf NPROC_ONLN").read.to_i
         elsif File.executable?("/usr/sbin/sysctl")
-          IO.popen(%w[/usr/sbin/sysctl -n hw.ncpu]).read.to_i
+          IO.popen("/usr/sbin/sysctl -n hw.ncpu").read.to_i
         elsif File.executable?("/sbin/sysctl")
-          IO.popen(%w[/sbin/sysctl -n hw.ncpu]).read.to_i
+          IO.popen("/sbin/sysctl -n hw.ncpu").read.to_i
         else
           $stderr.puts "Unknown platform: " + RbConfig::CONFIG["target_os"]
           $stderr.puts "Assuming 1 processor."
@@ -175,7 +175,7 @@ module Parallel
       @physical_processor_count ||= begin
         ppc = case RbConfig::CONFIG["target_os"]
         when /darwin1/
-          IO.popen(%w[/usr/sbin/sysctl -n hw.physicalcpu]).read.to_i
+          IO.popen("/usr/sbin/sysctl -n hw.physicalcpu").read.to_i
         when /linux/
           cores = {}  # unique physical ID / core ID combinations
           phy = 0


### PR DESCRIPTION
This PR fixex https://github.com/grosser/parallel/issues/92

All the calls to popen have been changed to match a compatible signature for `IO.popen` as described in [1.8.7](http://ruby-doc.org/core-1.8.7/IO.html#method-c-popen), [1.9.3](http://ruby-doc.org/core-1.9.3/IO.html#method-c-popen), and [2.0.0](http://ruby-doc.org/core-2.0.0/IO.html#method-c-popen)

The fix has been tested in Mac OSX and Linux, in ree-1.8.7-2012.02, ruby-1.9.3-p448 and ruby-2.0.0-p247
