### PR TITLE
rake: use built-in rspec functions

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,7 +1,10 @@
 require 'bundler/setup'
 require 'bundler/gem_tasks'
 require 'bump/tasks'
+require "rspec/core/rake_task"
 
-task :default do
-  sh "rspec spec/"
+RSpec::Core::RakeTask.new(:spec) do |t|
+  t.rspec_opts = '--backtrace --color'
 end
+
+task :default => :spec


### PR DESCRIPTION
In the conversion to bundler, a09dcbdced6418e32ec69466eb90de6355e83937, the default rake task was changed to simply shell out to rspec. This pull request restores the change to the Rakefile so that we continue to use the built-in rspec rake task, along with the `--backtrace` and `--color` customizations.
