### PR TITLE
Initialize instance variable before access

### DIFF
--- a/lib/parallel.rb
+++ b/lib/parallel.rb
@@ -69,6 +69,7 @@ module Parallel
       @items = array.to_a unless @lambda # turn Range and other Enumerable-s into an Array
       @mutex = mutex
       @index = -1
+      @stopped = false
     end
 
     def producer?


### PR DESCRIPTION
Fixes a warning:

```
/home/mbj/.gem/ruby/2.1.3/gems/parallel-1.3.2/lib/parallel.rb:95:
```
