### PR TITLE
Add progress_options option to Parallel that specifies options to pass a...

### DIFF
--- a/lib/parallel.rb
+++ b/lib/parallel.rb
@@ -201,14 +201,20 @@ module Parallel
     private
 
     def add_progress_bar!(items, options)
-      if title = options[:progress]
+      if progress_options = options[:progress]
         raise "Progressbar and producers don't mix" if items.producer?
         require 'ruby-progressbar'
-        progress = ProgressBar.create(
-          :title => title,
-          :total => items.size,
-          :format => '%t |%E | %B | %a'
-        )
+
+        if progress_options.respond_to? :to_str
+          progress_options = { title: progress_options.to_str }
+        end
+
+        progress_options = {
+          total: items.size,
+          format: '%t |%E | %B | %a'
+        }.merge(progress_options)
+
+        progress = ProgressBar.create(progress_options)
         old_finish = options[:finish]
         options[:finish] = lambda do |item, i, result|
           old_finish.call(item, i, result) if old_finish

--- a/spec/cases/progress_with_options.rb
+++ b/spec/cases/progress_with_options.rb
@@ -1,0 +1,27 @@
+require './spec/cases/helper'
+
+# ruby-progressbar ignores the format string you give it
+# unless the output is a TTY.  When running in the test,
+# the output is not a TTY, so we cannot test that the format
+# string you pass overrides parallel's default.  So, we pretend
+# that stdout is a TTY to test that the options are merged
+# in the correct way.
+tty_stdout = $stdout
+class << tty_stdout
+  def tty?
+    true
+  end
+end
+
+parallel_options = {
+  :progress => {
+    :title => "Reticulating Splines",
+    :progress_mark => ';',
+    :format => "%t %w",
+    :output => tty_stdout
+  }
+}
+
+Parallel.map(1..50, parallel_options) do
+  2
+end

--- a/spec/parallel_spec.rb
+++ b/spec/parallel_spec.rb
@@ -467,12 +467,16 @@ describe Parallel do
   end
 
   describe "progress" do
-    it "shows" do
+    it "takes the title from :progress" do
       `ruby spec/cases/progress.rb`.sub(/=+/, '==').strip.should == "Doing stuff: |==|"
     end
 
     it "works with :finish" do
       `ruby spec/cases/progress_with_finish.rb`.strip.sub(/=+/, '==').gsub(/\n+/,"\n").should == "Doing stuff: |==|\n100"
+    end
+
+    it "takes the title from :progress[:title] and passes options along" do
+      `ruby spec/cases/progress_with_options.rb`.should =~ /Reticulating Splines ;+ \d+ ;+/
     end
   end
 


### PR DESCRIPTION
...long to the ruby-progressbar library.

My use case for this is outputting the progress bar on standard error by using Parallel like this:

```ruby
Parallel.map(ary, progress: "Calculating", progress_options: { output: STDERR })
```

This would replace the monkey-patch here: https://github.com/MarkyMarkMcDonald/twitch_arena_parsing/commit/ac43c073ebdf7c1e387c74f8d801714af90191d0