### PR TITLE
Pass index number of process/thread to the producer lambda

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -37,6 +37,7 @@ items = [1,2,3]
 Parallel.each(lambda{ items.pop || Parallel::Stop }){|number| ... }
 ```
 
+The lambda receives a single argument, the index of the process/thread (0, 1, ...), in case you want to produce items differently for different processes/threads.
 
 Processes/Threads are workers, they grab the next piece of work when they finish.
 

--- a/lib/parallel.rb
+++ b/lib/parallel.rb
@@ -96,7 +96,7 @@ module Parallel
         # - do not call lambda after it has returned Stop
         item, index = @mutex.synchronize do
           return if @stopped
-          item = @lambda.call(i)
+          item = @lambda.call(*(@lambda.parameters.empty? ? [] : [i]))
           @stopped = (item == Parallel::Stop)
           return if @stopped
           [item, @index += 1]

--- a/lib/parallel.rb
+++ b/lib/parallel.rb
@@ -90,13 +90,13 @@ module Parallel
       end
     end
 
-    def next
+    def next(i)
       if producer?
         # - index and item stay in sync
         # - do not call lambda after it has returned Stop
         item, index = @mutex.synchronize do
           return if @stopped
-          item = @lambda.call
+          item = @lambda.call(i)
           @stopped = (item == Parallel::Stop)
           return if @stopped
           [item, @index += 1]
@@ -238,11 +238,11 @@ module Parallel
       results = []
       exception = nil
 
-      in_threads(options) do
+      in_threads(options) do |i|
         # as long as there are more items, work on one of them
         loop do
           break if exception
-          item, index = items.next
+          item, index = items.next(i)
           break unless index
 
           begin
@@ -272,7 +272,7 @@ module Parallel
           begin
             loop do
               break if exception
-              item, index = items.next
+              item, index = items.next(i)
               break unless index
 
               begin


### PR DESCRIPTION
Pass index number of process/thread to the producer lambda, so that items can be produced differently for different processes/threads.

For example, when precompiling assets in parallel, it can be more efficient for one process to handle all javascript and another to handle all css (otherwise, the processes end up duplicating a lot of dependency work).

The change should be backwards compatible with lambdas with no declared parameters.

I can add tests if desired but wanted to find out first if this change was acceptable to you.

Thanks for a great gem!