### PR TITLE
Fixes #140 (travis testing for other ruby impls)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,4 +6,28 @@ rvm:
   - 2.0.0
   - 2.1.6
   - 2.2.2
-
+  - jruby-19mode
+  - jruby-9.0.0.0
+  - rbx-2
+jdk:
+  - openjdk7
+  - oraclejdk7
+  - oraclejdk8
+matrix:
+  exclude:
+    - rvm: 1.9.3
+      jdk: oraclejdk8
+    - rvm: 1.9.3
+      jdk: oraclejdk7
+    - rvm: 2.0.0
+      jdk: oraclejdk8
+    - rvm: 2.0.0
+      jdk: oraclejdk7
+    - rvm: 2.1.6
+      jdk: oraclejdk8
+    - rvm: 2.1.6
+      jdk: oraclejdk7
+    - rvm: 2.2.2
+      jdk: oraclejdk8
+    - rvm: 2.2.2
+      jdk: oraclejdk7

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: ruby
 bundler_args: ""
+sudo: false
 
 rvm:
   - 1.9.3
@@ -11,23 +12,28 @@ rvm:
   - rbx-2
 jdk:
   - openjdk7
-  - oraclejdk7
   - oraclejdk8
 matrix:
   exclude:
     - rvm: 1.9.3
       jdk: oraclejdk8
     - rvm: 1.9.3
-      jdk: oraclejdk7
+      jdk: openjdk7
     - rvm: 2.0.0
       jdk: oraclejdk8
     - rvm: 2.0.0
-      jdk: oraclejdk7
+      jdk: openjdk7
     - rvm: 2.1.6
       jdk: oraclejdk8
     - rvm: 2.1.6
-      jdk: oraclejdk7
+      jdk: openjdk7
     - rvm: 2.2.2
       jdk: oraclejdk8
     - rvm: 2.2.2
-      jdk: oraclejdk7
+      jdk: openjdk7
+    - rvm: rbx-2
+      jdk: openjdk7
+    - rvm: rbx-2
+      jdk: openjdk8
+  allow_failures:
+    - rvm: rbx-2

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,22 +17,12 @@ matrix:
   exclude:
     - rvm: 1.9.3
       jdk: oraclejdk8
-    - rvm: 1.9.3
-      jdk: openjdk7
     - rvm: 2.0.0
       jdk: oraclejdk8
-    - rvm: 2.0.0
-      jdk: openjdk7
     - rvm: 2.1.6
       jdk: oraclejdk8
-    - rvm: 2.1.6
-      jdk: openjdk7
     - rvm: 2.2.2
       jdk: oraclejdk8
-    - rvm: 2.2.2
-      jdk: openjdk7
-    - rvm: rbx-2
-      jdk: openjdk7
     - rvm: rbx-2
       jdk: openjdk8
   allow_failures:

--- a/Gemfile
+++ b/Gemfile
@@ -9,4 +9,6 @@ gem 'ruby-progressbar'
 gem 'rspec-rerun'
 gem 'rspec-legacy_formatters'
 
-gem 'mysql2', :group => :mysql
+gem 'mysql2', :group => :mysql, :platform => :ruby
+gem 'jdbc-mysql', :platform => :jruby
+gem 'activerecord-jdbc-adapter', :platform => :jruby

--- a/Readme.md
+++ b/Readme.md
@@ -1,4 +1,6 @@
-Run any code in parallel Processes(> use all CPUs) or Threads(> speedup blocking operations).<br/>
+*It appears that parallel does not currently run on Rubinius.*
+
+Run any code in parallel Processes(> use all CPUas) or Threads(> speedup blocking operations).<br/>
 Best suited for map-reduce or e.g. parallel downloads/uploads.
 
 Install


### PR DESCRIPTION
This adds JRuby in 1.9 mode (which should track the 1.7 branch) and also JRuby 9000 which was recently released (it's ruby 2.2.2). These are run on three different JVMs as well. It should also test against Rubinus 2.

There's also no point in testing on the different jvms for straight-up mri so those combinations are excluded.
