### PR TITLE
add options[:setup_proc] and master process waits all worker being ready

### DIFF
--- a/lib/parallel.rb
+++ b/lib/parallel.rb
@@ -222,7 +222,6 @@ module Parallel
       size = [job_factory.size, size].min
 
       options[:return_results] = (options[:preserve_results] != false || !!options[:finish])
-      add_progress_bar!(job_factory, options)
 
       if size == 0
         work_direct(job_factory, options, &block)
@@ -264,6 +263,7 @@ module Parallel
 
     def work_direct(job_factory, options, &block)
       results = []
+      add_progress_bar!(job_factory, options)
       while set = job_factory.next
         item, index = set
         results << with_instrumentation(item, index, options) do
@@ -279,6 +279,7 @@ module Parallel
       results_mutex = Mutex.new # arrays are not thread-safe on jRuby
       exception = nil
 
+      add_progress_bar!(job_factory, options)
       in_threads(options) do
         # as long as there are more jobs, work on one of them
         while !exception && set = job_factory.next
@@ -303,6 +304,7 @@ module Parallel
       results_mutex = Mutex.new # arrays are not thread-safe
       exception = nil
 
+      add_progress_bar!(job_factory, options)
       UserInterruptHandler.kill_on_ctrl_c(workers.map(&:pid), options) do
         in_threads(options) do |i|
           worker = workers[i]
@@ -341,9 +343,13 @@ module Parallel
 
     def create_workers(job_factory, options, &block)
       workers = []
+      print "creating workers "
+      STDOUT.flush
+
       Array.new(options[:count]).each do
         workers << worker(job_factory, options.merge(:started_workers => workers), &block)
       end
+      print " done\n"
       workers
     end
 
@@ -358,6 +364,13 @@ module Parallel
           parent_write.close
           parent_read.close
 
+          setup_proc = options[:setup_proc]
+          if setup_proc && setup_proc.respond_to?(:call)
+            setup_proc.call
+          end
+
+          child_write.write('.')
+
           process_incoming_jobs(child_read, child_write, job_factory, options, &block)
         ensure
           child_read.close
@@ -367,6 +380,10 @@ module Parallel
 
       child_read.close
       child_write.close
+
+      parent_read.read(1)
+      print '.'
+      STDOUT.flush
 
       Worker.new(parent_read, parent_write, pid)
     end


### PR DESCRIPTION
add options[:setup_proc] to do some setup task before starting actual job.

To be sure all workers finished setup task, master process does not start actual job and progress-bar until all worker being ready.