### PR TITLE
add queue interface

### DIFF
--- a/lib/parallel.rb
+++ b/lib/parallel.rb
@@ -1,7 +1,6 @@
 require 'rbconfig'
 require 'parallel/version'
 require 'parallel/processor_count'
-require 'parallel/queue'
 
 module Parallel
   extend Parallel::ProcessorCount
@@ -236,10 +235,6 @@ module Parallel
 
     def map_with_index(array, options={}, &block)
       map(array, options.merge(:with_index => true), &block)
-    end
-
-    def queue
-      ParallelQueue.new(processor_count)
     end
 
     private

--- a/lib/parallel.rb
+++ b/lib/parallel.rb
@@ -1,6 +1,7 @@
 require 'rbconfig'
 require 'parallel/version'
 require 'parallel/processor_count'
+require 'parallel/queue'
 
 module Parallel
   extend Parallel::ProcessorCount
@@ -235,6 +236,10 @@ module Parallel
 
     def map_with_index(array, options={}, &block)
       map(array, options.merge(:with_index => true), &block)
+    end
+
+    def queue
+      ParallelQueue.new(processor_count)
     end
 
     private

--- a/lib/parallel/queue.rb
+++ b/lib/parallel/queue.rb
@@ -1,56 +1,32 @@
+require 'thread'
 # ==============================================================================
-# Author: Ralf Mueller, ralf.mueller@mpimet.de                                 
+# Author: Ralf Mueller, ralf.mueller@mpimet.mpg.de
 #         suggestions from Robert Klemme (https://www.ruby-forum.com/topic/68001#86298)
-#                                                                            
+#
 # ==============================================================================
-# Sized Queue for limiting the number of parallel jobs                       
-# ==============================================================================                          
-class ParallelQueue
-  include Parallel::ProcessorCount
+include Parallel::ProcessorCount
 
-  attr_reader :workers, :threads
-
-  # Create a new queue qith a given number of worker threads
-  def initialize(nWorkers=processor_count,debug=:off)
-    @workers = nWorkers
-    @queue   = Queue.new
-    @debug   = debug
+class Queue
+  alias :qpush :push
+  def push (*item, &block)
+    qpush(item   ) unless item.empty?
+    qpush([block]) unless block.nil?
   end
-
-  # borrow some useful methods from Queue class
-  [:size,:length,:clear,:empty?].each {|method|
-    define_method(method) { @queue.send(method) }
-  }
-
-  # Put jobs into the queue. Use
-  #   proc,args for single methods
-  #   object,:method,args for sende messages to objects
-  def push(*item,&block)
-    @queue << item    unless item.empty?
-    @queue << [block] unless block.nil?
-  end
-
-  # Start workers to run through the queue
-  def run
-    @threads = (1..@workers).map {|i|
-      Thread.new(@queue) {|q|
-        until ( q == ( task = q.deq ) )
-          if task.size > 1
-            if task[0].kind_of? Proc
-              # Expects proc/lambda with arguments, e.g. [mysqrt,2.789]
-              task[0].call(*task[1..-1])
-            else
-              # expect an object in task[0] and one of its methods with arguments in task[1] as a symbol
-              # e.g. [a,[:attribute=,1]
-              task[0].send(task[1],*task[2..-1])
-            end
-          else
-            task[0].call
-          end
+  def run(workers=processor_count)
+    qpush(Parallel::Stop)
+    Parallel.map(self,:in_threads => workers) {|task|
+      if task.size > 1
+        if task[0].kind_of? Proc
+          # Expects proc/lambda with arguments, e.g. [mysqrt,2.789]
+          task[0].call(*task[1..-1])
+        else
+          # expect an object in task[0] and one of its methods with arguments in task[1] as a symbol
+          # e.g. [a,[:attribute=,1]
+          task[0].send(task[1],*task[2..-1])
         end
-      }
+      else
+        task[0].call
+      end
     }
-    @threads.size.times { @queue.enq @queue}
-    @threads.each {|t| t.join}
   end
 end

--- a/lib/parallel/queue.rb
+++ b/lib/parallel/queue.rb
@@ -4,24 +4,28 @@ require 'thread'
 #         suggestions from Robert Klemme (https://www.ruby-forum.com/topic/68001#86298)
 #
 # ==============================================================================
-include Parallel::ProcessorCount
 
-class Queue
-  alias :qpush :push
+class ParallelQueue < Queue
+  alias :queue_push :push
+  include Parallel::ProcessorCount
+
   def push (*item, &block)
-    qpush(item   ) unless item.empty?
-    qpush([block]) unless block.nil?
+    queue_push(item   ) unless item.empty?
+    queue_push([block]) unless block.nil?
   end
   def run(workers=processor_count)
-    qpush(Parallel::Stop)
+    queue_push(Parallel::Stop)
     Parallel.map(self,:in_threads => workers) {|task|
       if task.size > 1
         if task[0].kind_of? Proc
-          # Expects proc/lambda with arguments, e.g. [mysqrt,2.789]
+          # Expects proc/lambda with arguments,e.g.
+          # [mysqrt,2.789]
+          # [myproc,x,y,z]
           task[0].call(*task[1..-1])
         else
           # expect an object in task[0] and one of its methods with arguments in task[1] as a symbol
-          # e.g. [a,[:attribute=,1]
+          # e.g. [a,[:attribute=,1] or
+          # Math,:exp,0
           task[0].send(task[1],*task[2..-1])
         end
       else

--- a/lib/parallel/queue.rb
+++ b/lib/parallel/queue.rb
@@ -1,0 +1,56 @@
+# ==============================================================================
+# Author: Ralf Mueller, ralf.mueller@mpimet.de                                 
+#         suggestions from Robert Klemme (https://www.ruby-forum.com/topic/68001#86298)
+#                                                                            
+# ==============================================================================
+# Sized Queue for limiting the number of parallel jobs                       
+# ==============================================================================                          
+class ParallelQueue
+  include Parallel::ProcessorCount
+
+  attr_reader :workers, :threads
+
+  # Create a new queue qith a given number of worker threads
+  def initialize(nWorkers=processor_count,debug=:off)
+    @workers = nWorkers
+    @queue   = Queue.new
+    @debug   = debug
+  end
+
+  # borrow some useful methods from Queue class
+  [:size,:length,:clear,:empty?].each {|method|
+    define_method(method) { @queue.send(method) }
+  }
+
+  # Put jobs into the queue. Use
+  #   proc,args for single methods
+  #   object,:method,args for sende messages to objects
+  def push(*item,&block)
+    @queue << item    unless item.empty?
+    @queue << [block] unless block.nil?
+  end
+
+  # Start workers to run through the queue
+  def run
+    @threads = (1..@workers).map {|i|
+      Thread.new(@queue) {|q|
+        until ( q == ( task = q.deq ) )
+          if task.size > 1
+            if task[0].kind_of? Proc
+              # Expects proc/lambda with arguments, e.g. [mysqrt,2.789]
+              task[0].call(*task[1..-1])
+            else
+              # expect an object in task[0] and one of its methods with arguments in task[1] as a symbol
+              # e.g. [a,[:attribute=,1]
+              task[0].send(task[1],*task[2..-1])
+            end
+          else
+            task[0].call
+          end
+        end
+      }
+    }
+    @threads.size.times { @queue.enq @queue}
+    @threads.each {|t| t.join}
+  end
+end

--- a/test/test_parallel_queue.rb
+++ b/test/test_parallel_queue.rb
@@ -1,0 +1,57 @@
+require 'minitest/autorun'
+$:.unshift File.join(File.dirname(__FILE__),"..","lib")
+require 'parallel'
+require 'parallel/queue'
+
+class TestParallelQueue < Minitest::Test
+
+  def test_blocks
+    q = ParallelQueue.new
+
+    itemsA = %w[a:3:b x:55:x K:981:foo:tra]
+    itemsB = %w[a|5|b x|11|x K|187|foo|tra]
+
+    itemsA.each {|item|
+      q.push {
+        item.split(':')[1].to_i
+      }
+    }
+    itemsB.each {|item|
+      q.push {
+        item.split('|')[1].to_i
+      }
+    }
+    results = q.run.sort
+    assert_equal([3,5,11,55,187,981],results)
+  end
+
+  def test_procs
+    q = ParallelQueue.new
+
+    myProc       = lambda {|r| Math.sqrt(r)}
+    pressure     = lambda {|z|
+      1013.25*Math.exp((-1)*(1.602769777072154)*Math.log((Math.exp(z/10000.0)*213.15+75.0)/288.15))
+    }
+    temperature  = lambda {|z|
+      213.0+75.0*Math.exp((-1)*z/10000.0)-273.15
+    }
+    vectorLength = lambda {|x,y,z| Math.sqrt(x*x + y*y + z*z) }
+
+    q.push(myProc,4.0)
+    q.push(Math,:sqrt,16.0)
+    [0,10,20,50,100,200,500,1000].map(&:to_f).each {|z|
+      q.push(pressure,z)
+      q.push(temperature,z)
+    }
+    q.push(Math,:sqrt,529.0)
+    q.push(vectorLength,0,1,0)
+    q.push(vectorLength,0,1,1)
+    q.push(vectorLength,1,1,1)
+
+    results = q.run(2).map {|f| f.round(2)}
+    assert_equal(
+      [1.0,1.41,1.73,2.0, 4.0, 7.71, 11.19, 13.36, 14.1, 14.48, 14.7, 14.78, 14.85, 23.0, 898.6, 954.56, 989.45, 1001.29, 1007.26, 1010.85, 1012.05, 1013.25],
+      results.sort
+    )
+  end
+end


### PR DESCRIPTION

Hi!
I have a parallel queue implementation ready and in use for some years (https://github.com/Try2Code/jobQueue). Your gem offers more flexibility in terms of controlling the jobs and getting results back. So I started to port some of my scripts from jobQueue towards parallel. But large blocks do not seem to fit into the array-like approach of Parallel.map. Here, the queue works better for me.

My question is, if the queue-class could be integrated into the parallel gem?

cheers
ralf