### PR TITLE
Don't call :finish hook if there was an exception

### DIFF
--- a/lib/parallel.rb
+++ b/lib/parallel.rb
@@ -417,9 +417,8 @@ module Parallel
       on_finish = options[:finish]
       options[:mutex].synchronize { on_start.call(item, index) } if on_start
       result = yield
-      result unless options[:preserve_results] == false
-    ensure
       options[:mutex].synchronize { on_finish.call(item, index, result) } if on_finish
+      result unless options[:preserve_results] == false
     end
   end
 end

--- a/spec/cases/with_break_before_finish.rb
+++ b/spec/cases/with_break_before_finish.rb
@@ -3,18 +3,17 @@ require './spec/cases/helper'
 method = ENV.fetch('METHOD')
 in_worker_type = "in_#{ENV.fetch('WORKER_TYPE')}".to_sym
 
-begin
-  finish = lambda do |_item, _index, _result|
-    print " called"
-  end
-
-  Parallel.public_send(method, 1..10, in_worker_type => 4, finish: finish) do |x|
-    sleep 0.2
-    if x != 3
-      raise Parallel::Break
-    end
-    print x
-    x
-  end
-rescue
+finish = lambda do |_item, _index, _result|
+  sleep 0.1
+  print "finish hook called"
 end
+
+result = Parallel.public_send(method, 1..100, in_worker_type => 4, finish: finish) do |x|
+  sleep 0.1 # let workers start
+  raise Parallel::Break if x == 1
+  sleep 0.2
+  print x
+  x
+end
+
+print " Parallel::Break raised"

--- a/spec/cases/with_break_before_finish.rb
+++ b/spec/cases/with_break_before_finish.rb
@@ -1,0 +1,20 @@
+require './spec/cases/helper'
+
+method = ENV.fetch('METHOD')
+in_worker_type = "in_#{ENV.fetch('WORKER_TYPE')}".to_sym
+
+begin
+  finish = lambda do |_item, _index, _result|
+    print " called"
+  end
+
+  Parallel.public_send(method, 1..10, in_worker_type => 4, finish: finish) do |x|
+    sleep 0.2
+    if x != 3
+      raise Parallel::Break
+    end
+    print x
+    x
+  end
+rescue
+end

--- a/spec/cases/with_exception_before_finish.rb
+++ b/spec/cases/with_exception_before_finish.rb
@@ -1,0 +1,20 @@
+require './spec/cases/helper'
+
+method = ENV.fetch('METHOD')
+in_worker_type = "in_#{ENV.fetch('WORKER_TYPE')}".to_sym
+
+begin
+  finish = lambda do |_item, _index, _result|
+    print " called"
+  end
+
+  Parallel.public_send(method, 1..10, in_worker_type => 4, finish: finish) do |x|
+    if x != 3
+      sleep 0.2
+      raise 'foo'
+    end
+    print x
+    x
+  end
+rescue
+end

--- a/spec/cases/with_exception_before_finish.rb
+++ b/spec/cases/with_exception_before_finish.rb
@@ -3,6 +3,9 @@ require './spec/cases/helper'
 method = ENV.fetch('METHOD')
 in_worker_type = "in_#{ENV.fetch('WORKER_TYPE')}".to_sym
 
+class ParallelTestError < StandardError
+end
+
 begin
   finish = lambda do |_item, _index, _result|
     print " called"
@@ -11,10 +14,10 @@ begin
   Parallel.public_send(method, 1..10, in_worker_type => 4, finish: finish) do |x|
     if x != 3
       sleep 0.2
-      raise 'foo'
+      raise ParallelTestError
     end
     print x
     x
   end
-rescue
+rescue ParallelTestError
 end

--- a/spec/cases/with_exception_in_start_before_finish.rb
+++ b/spec/cases/with_exception_in_start_before_finish.rb
@@ -1,0 +1,23 @@
+require './spec/cases/helper'
+
+method = ENV.fetch('METHOD')
+in_worker_type = "in_#{ENV.fetch('WORKER_TYPE')}".to_sym
+
+begin
+  start = lambda do |_item, _index|
+    if _item != 3
+      sleep 0.2
+      raise 'foo'
+    end
+  end
+
+  finish = lambda do |_item, _index, _result|
+    print " called"
+  end
+
+  Parallel.public_send(method, 1..10, in_worker_type => 4, start: start, finish: finish) do |x|
+    print x
+    x
+  end
+rescue
+end

--- a/spec/cases/with_exception_in_start_before_finish.rb
+++ b/spec/cases/with_exception_in_start_before_finish.rb
@@ -3,11 +3,14 @@ require './spec/cases/helper'
 method = ENV.fetch('METHOD')
 in_worker_type = "in_#{ENV.fetch('WORKER_TYPE')}".to_sym
 
+class ParallelTestError < StandardError
+end
+
 begin
-  start = lambda do |_item, _index|
-    if _item != 3
+  start = lambda do |item, _index|
+    if item != 3
       sleep 0.2
-      raise 'foo'
+      raise ParallelTestError
     end
   end
 
@@ -19,5 +22,5 @@ begin
     print x
     x
   end
-rescue
+rescue ParallelTestError
 end

--- a/spec/parallel_spec.rb
+++ b/spec/parallel_spec.rb
@@ -253,7 +253,7 @@ describe Parallel do
       end
 
       it "does not call the finish hook when a worker raises Break in #{type}" do
-        `METHOD=map WORKER_TYPE=#{type} ruby spec/cases/with_break_before_finish.rb 2>&1`.should == '3 called'
+        `METHOD=map WORKER_TYPE=#{type} ruby spec/cases/with_break_before_finish.rb 2>&1`.should =~ /^\d{3}(finish hook called){3} Parallel::Break raised$/
       end
 
       it "does not call the finish hook when a start hook fails with #{type}" do
@@ -446,7 +446,7 @@ describe Parallel do
       end
 
       it "does not call the finish hook when a worker raises Break in #{type}" do
-        `METHOD=each WORKER_TYPE=#{type} ruby spec/cases/with_break_before_finish.rb 2>&1`.should == '3 called'
+        `METHOD=each WORKER_TYPE=#{type} ruby spec/cases/with_break_before_finish.rb 2>&1`.should =~ /^\d{3}(finish hook called){3} Parallel::Break raised$/
       end
 
       it "does not call the finish hook when a start hook fails with #{type}" do

--- a/spec/parallel_spec.rb
+++ b/spec/parallel_spec.rb
@@ -247,6 +247,18 @@ describe Parallel do
       it "stops all workers when a finish hook fails with #{type}" do
         `METHOD=map WORKER_TYPE=#{type} ruby spec/cases/with_exception_in_finish.rb 2>&1`.should =~ /^\d{4} raised$/
       end
+
+      it "does not call the finish hook when a worker fails with #{type}" do
+        `METHOD=map WORKER_TYPE=#{type} ruby spec/cases/with_exception_before_finish.rb 2>&1`.should == '3 called'
+      end
+
+      it "does not call the finish hook when a worker raises Break in #{type}" do
+        `METHOD=map WORKER_TYPE=#{type} ruby spec/cases/with_break_before_finish.rb 2>&1`.should == '3 called'
+      end
+
+      it "does not call the finish hook when a start hook fails with #{type}" do
+        `METHOD=map WORKER_TYPE=#{type} ruby spec/cases/with_exception_in_start_before_finish.rb 2>&1`.should == '3 called'
+      end
     end
 
     it "can run with 0 threads" do
@@ -427,6 +439,18 @@ describe Parallel do
 
       it 'stops all workers when a finish hook fails with processes' do
         `METHOD=each WORKER_TYPE=#{type} ruby spec/cases/with_exception_in_finish.rb 2>&1`.should =~ /^\d{4} raised$/
+      end
+
+      it "does not call the finish hook when a worker fails with #{type}" do
+        `METHOD=each WORKER_TYPE=#{type} ruby spec/cases/with_exception_before_finish.rb 2>&1`.should == '3 called'
+      end
+
+      it "does not call the finish hook when a worker raises Break in #{type}" do
+        `METHOD=each WORKER_TYPE=#{type} ruby spec/cases/with_break_before_finish.rb 2>&1`.should == '3 called'
+      end
+
+      it "does not call the finish hook when a start hook fails with #{type}" do
+        `METHOD=each WORKER_TYPE=#{type} ruby spec/cases/with_exception_in_start_before_finish.rb 2>&1`.should == '3 called'
       end
     end
   end


### PR DESCRIPTION
I couldn't find any good reason for the :finish hook to be inside an ensure block.

But because it is, the :finish hook will be called with a `nil` value for `result` if there is an exception on the :start hook or `yield` call. This is (IMHO) unexpected behavior, and I was quite confused as to why my function (which should always be called with a non-nil value) was receiving `nil`.