### PR TITLE
Added case files for mysql and postgres (postgres is failing).

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -49,6 +49,7 @@ GEM
       rspec
     rspec-support (3.2.2)
     ruby-progressbar (1.7.5)
+    sqlite3 (1.3.11)
     thread_safe (0.3.5)
     thread_safe (0.3.5-java)
     tzinfo (1.2.2)
@@ -69,3 +70,4 @@ DEPENDENCIES
   rspec-legacy_formatters
   rspec-rerun
   ruby-progressbar
+  sqlite3

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -28,6 +28,7 @@ GEM
     json (1.8.2-java)
     minitest (5.6.1)
     mysql2 (0.3.18)
+    pg (0.18.4)
     rake (10.4.2)
     rspec (3.2.0)
       rspec-core (~> 3.2.0)
@@ -62,11 +63,9 @@ DEPENDENCIES
   bump
   mysql2
   parallel!
+  pg
   rake
   rspec
   rspec-legacy_formatters
   rspec-rerun
   ruby-progressbar
-
-BUNDLED WITH
-   1.11.2

--- a/parallel.gemspec
+++ b/parallel.gemspec
@@ -9,4 +9,6 @@ Gem::Specification.new name, Parallel::VERSION do |s|
   s.files = `git ls-files lib MIT-LICENSE.txt`.split("\n")
   s.license = "MIT"
   s.required_ruby_version = '>= 1.9.3'
+
+  s.add_development_dependency 'pg'
 end

--- a/parallel.gemspec
+++ b/parallel.gemspec
@@ -11,4 +11,5 @@ Gem::Specification.new name, Parallel::VERSION do |s|
   s.required_ruby_version = '>= 1.9.3'
 
   s.add_development_dependency 'pg'
+  s.add_development_dependency 'sqlite3'
 end

--- a/spec/cases/each_with_ar_mysql.rb
+++ b/spec/cases/each_with_ar_mysql.rb
@@ -1,0 +1,51 @@
+require './spec/cases/helper'
+require "active_record"
+require "mysql2"
+STDOUT.sync = true
+
+
+database = "parallel_with_ar_test"
+# Assumes 'root'@'localhost' has no password
+`mysql -u root #{database} -e '' || mysql -u root -e 'create database #{database};'`
+
+ActiveRecord::Schema.verbose = false
+ActiveRecord::Base.establish_connection(
+  :adapter => "mysql2",
+  :database => database
+)
+
+class User < ActiveRecord::Base
+end
+
+# create tables
+unless User.table_exists?
+  ActiveRecord::Schema.define(:version => 1) do
+    create_table :users do |t|
+      t.string :name
+    end
+  end
+end
+
+User.delete_all
+
+3.times { User.create!(:name => "X") }
+
+print "Parent: "
+puts User.first.name
+
+print "Parallel (fork): "
+Parallel.each(User.all, in_processes: 3) do |user|
+  print user.name
+end
+ActiveRecord::Base.connection.reconnect!
+
+print "\nParent: "
+puts User.first.name
+
+print "Parallel (threads): "
+Parallel.each(User.all, in_threads: 3) do |user|
+  print user.name
+end
+
+print "\nParent: "
+puts User.first.name

--- a/spec/cases/each_with_ar_postgres.rb
+++ b/spec/cases/each_with_ar_postgres.rb
@@ -1,0 +1,51 @@
+require './spec/cases/helper'
+require "active_record"
+require "pg"
+STDOUT.sync = true
+
+
+database = "parallel_with_ar_test"
+# Assumes 'postgres' user is SUPERUSER
+`createdb #{database}` unless `psql -l | grep parallel_with_ar_test`
+
+ActiveRecord::Schema.verbose = false
+ActiveRecord::Base.establish_connection(
+  :adapter => "postgresql",
+  :database => database
+)
+
+class User < ActiveRecord::Base
+end
+
+# create tables
+unless User.table_exists?
+  ActiveRecord::Schema.define(:version => 1) do
+    create_table :users do |t|
+      t.string :name
+    end
+  end
+end
+
+User.delete_all
+
+3.times { User.create!(:name => "X") }
+
+print "Parent: "
+puts User.first.name
+
+print "Parallel (fork): "
+Parallel.each(User.all, in_processes: 3) do |user|
+  print user.name
+end
+ActiveRecord::Base.connection.reconnect!
+
+print "\nParent: "
+puts User.first.name
+
+print "Parallel (threads): "
+Parallel.each(User.all, in_threads: 3) do |user|
+  print user.name
+end
+
+print "\nParent: "
+puts User.first.name

--- a/spec/cases/each_with_ar_sqlite.rb
+++ b/spec/cases/each_with_ar_sqlite.rb
@@ -1,0 +1,47 @@
+require './spec/cases/helper'
+require "active_record"
+require "sqlite3"
+STDOUT.sync = true
+
+
+ActiveRecord::Schema.verbose = false
+ActiveRecord::Base.establish_connection(
+  :adapter => "sqlite3",
+  :database => ":memory:"
+)
+
+class User < ActiveRecord::Base
+end
+
+# create tables
+unless User.table_exists?
+  ActiveRecord::Schema.define(:version => 1) do
+    create_table :users do |t|
+      t.string :name
+    end
+  end
+end
+
+User.delete_all
+
+3.times { User.create!(:name => "X") }
+
+print "Parent: "
+puts User.first.name
+
+print "Parallel (fork): "
+Parallel.each(User.all, in_processes: 3) do |user|
+  print user.name
+end
+ActiveRecord::Base.connection.reconnect!
+
+print "\nParent: "
+puts User.first.name
+
+print "Parallel (threads): "
+Parallel.each(User.all, in_threads: 3) do |user|
+  print user.name
+end
+
+print "\nParent: "
+puts User.first.name

--- a/spec/parallel_spec.rb
+++ b/spec/parallel_spec.rb
@@ -433,6 +433,10 @@ describe Parallel do
       `ruby spec/cases/each_with_ar_postgres.rb`.should == "Parent: X\nParallel (fork): XXX\nParent: X\nParallel (threads): XXX\nParent: X\n"
     end
 
+    it "works with SQLite" do
+      `ruby spec/cases/each_with_ar_sqlite.rb`.should == "Parent: X\nParallel (fork): XXX\nParent: X\nParallel (threads): XXX\nParent: X\n"
+    end
+
 
     worker_types.each do |type|
       it "stops all workers when one fails in #{type}" do

--- a/spec/parallel_spec.rb
+++ b/spec/parallel_spec.rb
@@ -425,6 +425,15 @@ describe Parallel do
       `ruby spec/cases/each_in_place.rb`.should == 'ab'
     end
 
+    it "works with MySQL" do
+      `ruby spec/cases/each_with_ar_mysql.rb`.should == "Parent: X\nParallel (fork): XXX\nParent: X\nParallel (threads): XXX\nParent: X\n"
+    end
+
+    it "works with Postgres" do
+      `ruby spec/cases/each_with_ar_postgres.rb`.should == "Parent: X\nParallel (fork): XXX\nParent: X\nParallel (threads): XXX\nParent: X\n"
+    end
+
+
     worker_types.each do |type|
       it "stops all workers when one fails in #{type}" do
         `METHOD=each WORKER_TYPE=#{type} ruby spec/cases/with_exception.rb 2>&1`.should =~ /^\d{4} raised$/


### PR DESCRIPTION
Run with ```rspec spec/parallel_spec.rb:429:432```

Testing against databases is quite annoying as it requires mysql and postgres to be installed and setup.  I tried to follow the "map_with_ar.rb" example as closely as possible.  

Other things to notice, I had to add "pg" to your gemspec so I could use it, but I added it as a development_dependency so it shouldn't be included for projects that use parallel.  



Here's the output when I run it.

```
$ rspec spec/parallel_spec.rb:429:432
Run options: include {:locations=>{"./spec/parallel_spec.rb"=>[429, 432]}}
./Users/duffyjp/.rvm/gems/ruby-2.2.0/gems/activerecord-4.2.1/lib/active_record/connection_adapters/postgresql_adapter.rb:215:in `exec': server closed the connection unexpectedly (PG::UnableToSend)
	This probably means the server terminated abnormally
	before or while processing the request.
	from /Users/duffyjp/.rvm/gems/ruby-2.2.0/gems/activerecord-4.2.1/lib/active_record/connection_adapters/postgresql_adapter.rb:215:in `dealloc'
	from /Users/duffyjp/.rvm/gems/ruby-2.2.0/gems/activerecord-4.2.1/lib/active_record/connection_adapters/postgresql_adapter.rb:198:in `block in clear'
	from /Users/duffyjp/.rvm/gems/ruby-2.2.0/gems/activerecord-4.2.1/lib/active_record/connection_adapters/postgresql_adapter.rb:197:in `each_value'
	from /Users/duffyjp/.rvm/gems/ruby-2.2.0/gems/activerecord-4.2.1/lib/active_record/connection_adapters/postgresql_adapter.rb:197:in `clear'
	from /Users/duffyjp/.rvm/gems/ruby-2.2.0/gems/activerecord-4.2.1/lib/active_record/connection_adapters/postgresql_adapter.rb:258:in `clear_cache!'
	from /Users/duffyjp/.rvm/gems/ruby-2.2.0/gems/activerecord-4.2.1/lib/active_record/connection_adapters/abstract_adapter.rb:291:in `reconnect!'
	from /Users/duffyjp/.rvm/gems/ruby-2.2.0/gems/activerecord-4.2.1/lib/active_record/connection_adapters/postgresql_adapter.rb:275:in `reconnect!'
	from spec/cases/each_with_ar_postgres.rb:40:in `<main>'
F

Failures:

  1) Parallel.each works with Postgres
     Failure/Error: `ruby spec/cases/each_with_ar_postgres.rb`.should == "Parent: X\nParallel (fork): XXX\nParent: X\nParallel (threads): XXX\nParent: X\n"
       expected: "Parent: X\nParallel (fork): XXX\nParent: X\nParallel (threads): XXX\nParent: X\n"
            got: "Parent: X\nParallel (fork): XXX" (using ==)
       Diff:
       @@ -1,6 +1,3 @@
        Parent: X
        Parallel (fork): XXX
       -Parent: X
       -Parallel (threads): XXX
       -Parent: X
     # ./spec/parallel_spec.rb:433:in `block (3 levels) in <top (required)>'

Finished in 1.82 seconds (files took 0.1075 seconds to load)
2 examples, 1 failure

Failed examples:

rspec ./spec/parallel_spec.rb:432 # Parallel.each works with Postgres
```