### PR TITLE
Added an SQLite case

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,3 +10,4 @@ gem 'rspec-rerun'
 gem 'rspec-legacy_formatters'
 
 gem 'mysql2', :group => :mysql
+gem 'sqlite3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -48,6 +48,7 @@ GEM
       rspec
     rspec-support (3.2.2)
     ruby-progressbar (1.7.5)
+    sqlite3 (1.3.11)
     thread_safe (0.3.5)
     thread_safe (0.3.5-java)
     tzinfo (1.2.2)
@@ -67,6 +68,4 @@ DEPENDENCIES
   rspec-legacy_formatters
   rspec-rerun
   ruby-progressbar
-
-BUNDLED WITH
-   1.11.2
+  sqlite3

--- a/parallel.gemspec
+++ b/parallel.gemspec
@@ -9,4 +9,6 @@ Gem::Specification.new name, Parallel::VERSION do |s|
   s.files = `git ls-files lib MIT-LICENSE.txt`.split("\n")
   s.license = "MIT"
   s.required_ruby_version = '>= 1.9.3'
+
+  s.add_development_dependency 'sqlite3'
 end

--- a/parallel.gemspec
+++ b/parallel.gemspec
@@ -10,5 +10,4 @@ Gem::Specification.new name, Parallel::VERSION do |s|
   s.license = "MIT"
   s.required_ruby_version = '>= 1.9.3'
 
-  s.add_development_dependency 'sqlite3'
 end

--- a/spec/cases/each_with_ar_sqlite.rb
+++ b/spec/cases/each_with_ar_sqlite.rb
@@ -1,0 +1,47 @@
+require './spec/cases/helper'
+require "active_record"
+require "sqlite3"
+STDOUT.sync = true
+
+
+ActiveRecord::Schema.verbose = false
+ActiveRecord::Base.establish_connection(
+  :adapter => "sqlite3",
+  :database => ":memory:"
+)
+
+class User < ActiveRecord::Base
+end
+
+# create tables
+unless User.table_exists?
+  ActiveRecord::Schema.define(:version => 1) do
+    create_table :users do |t|
+      t.string :name
+    end
+  end
+end
+
+User.delete_all
+
+3.times { User.create!(:name => "X") }
+
+print "Parent: "
+puts User.first.name
+
+print "Parallel (fork): "
+Parallel.each(User.all, in_processes: 3) do |user|
+  print user.name
+end
+ActiveRecord::Base.connection.reconnect!
+
+print "\nParent: "
+puts User.first.name
+
+print "Parallel (threads): "
+Parallel.each(User.all, in_threads: 3) do |user|
+  print user.name
+end
+
+print "\nParent: "
+puts User.first.name

--- a/spec/cases/each_with_ar_sqlite.rb
+++ b/spec/cases/each_with_ar_sqlite.rb
@@ -29,19 +29,19 @@ User.delete_all
 print "Parent: "
 puts User.first.name
 
-print "Parallel (fork): "
-Parallel.each(User.all, in_processes: 3) do |user|
-  print user.name
+print "Parallel (threads): "
+Parallel.each([1], in_threads: 1) do
+  puts User.all.map(&:name).join
 end
-ActiveRecord::Base.connection.reconnect!
 
 print "\nParent: "
 puts User.first.name
 
-print "Parallel (threads): "
-Parallel.each(User.all, in_threads: 3) do |user|
-  print user.name
+print "Parallel (fork): "
+Parallel.each([1], in_processes: 1) do
+  puts User.all.map(&:name).join
 end
+ActiveRecord::Base.connection.reconnect!
 
 print "\nParent: "
 puts User.first.name

--- a/spec/parallel_spec.rb
+++ b/spec/parallel_spec.rb
@@ -425,7 +425,7 @@ describe Parallel do
       `ruby spec/cases/each_in_place.rb`.should == 'ab'
     end
 
-    it "works with SQLite" do
+    pending "works with SQLite" do
       `ruby spec/cases/each_with_ar_sqlite.rb`.should == "Parent: X\nParallel (fork): XXX\nParent: X\nParallel (threads): XXX\nParent: X\n"
     end
 

--- a/spec/parallel_spec.rb
+++ b/spec/parallel_spec.rb
@@ -425,6 +425,10 @@ describe Parallel do
       `ruby spec/cases/each_in_place.rb`.should == 'ab'
     end
 
+    it "works with SQLite" do
+      `ruby spec/cases/each_with_ar_sqlite.rb`.should == "Parent: X\nParallel (fork): XXX\nParent: X\nParallel (threads): XXX\nParent: X\n"
+    end
+
     worker_types.each do |type|
       it "stops all workers when one fails in #{type}" do
         `METHOD=each WORKER_TYPE=#{type} ruby spec/cases/with_exception.rb 2>&1`.should =~ /^\d{4} raised$/


### PR DESCRIPTION
Here's a case for SQLite.  Both in_processes and in_threads work!

I used an in memory DB so there's no DB setup to worry about.    

```
rspec  spec/parallel_spec.rb:428
Run options: include {:locations=>{"./spec/parallel_spec.rb"=>[428]}}
.

Finished in 1.4 seconds (files took 0.23123 seconds to load)
1 example, 0 failures
```