### PR TITLE
Broke the SQLite tests out by worker_type like the other .each tests.

### DIFF
--- a/spec/cases/each_with_ar_sqlite.rb
+++ b/spec/cases/each_with_ar_sqlite.rb
@@ -2,7 +2,7 @@ require './spec/cases/helper'
 require "active_record"
 require "sqlite3"
 STDOUT.sync = true
-
+in_worker_type = "in_#{ENV.fetch('WORKER_TYPE')}".to_sym
 
 ActiveRecord::Schema.verbose = false
 ActiveRecord::Base.establish_connection(
@@ -29,19 +29,11 @@ User.delete_all
 print "Parent: "
 puts User.first.name
 
-print "Parallel (threads): "
-Parallel.each([1], in_threads: 1) do
+print "Parallel (#{in_worker_type}): "
+Parallel.each([1], in_worker_type => 1) do
   puts User.all.map(&:name).join
 end
 
 print "\nParent: "
 puts User.first.name
 
-print "Parallel (fork): "
-Parallel.each([1], in_processes: 1) do
-  puts User.all.map(&:name).join
-end
-ActiveRecord::Base.connection.reconnect!
-
-print "\nParent: "
-puts User.first.name

--- a/spec/parallel_spec.rb
+++ b/spec/parallel_spec.rb
@@ -425,11 +425,11 @@ describe Parallel do
       `ruby spec/cases/each_in_place.rb`.should == 'ab'
     end
 
-    pending "works with SQLite" do
-      `ruby spec/cases/each_with_ar_sqlite.rb`.should == "Parent: X\nParallel (fork): XXX\nParent: X\nParallel (threads): XXX\nParent: X\n"
-    end
-
     worker_types.each do |type|
+      pending "works with SQLite in #{type}" do
+        `WORKER_TYPE=#{type} ruby spec/cases/each_with_ar_sqlite.rb`.should == "Parent: X\nParallel (in_#{type}): XXX\n\nParent: X\n"
+      end
+
       it "stops all workers when one fails in #{type}" do
         `METHOD=each WORKER_TYPE=#{type} ruby spec/cases/with_exception.rb 2>&1`.should =~ /^\d{4} raised$/
       end


### PR DESCRIPTION
The specs are still pending, but the this is much DRYer now, and won't attempt to run in_processes if you don't have that available on your system etc.

It's also much easier to read.