### PR TITLE
Bake in ActiveRecord support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,5 +10,5 @@ gem 'rspec-rerun'
 gem 'rspec-legacy_formatters'
 
 gem 'mysql2', :group => :mysql
-gem 'sqlite3'
-gem 'pg'
+gem 'pg' if `which psql` =~ /psql/
+gem 'sqlite3' if `which sqlite3` =~ /sqlite3/

--- a/Gemfile
+++ b/Gemfile
@@ -11,3 +11,4 @@ gem 'rspec-legacy_formatters'
 
 gem 'mysql2', :group => :mysql
 gem 'sqlite3'
+gem 'pg'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -28,6 +28,7 @@ GEM
     json (1.8.2-java)
     minitest (5.6.1)
     mysql2 (0.3.18)
+    pg (0.18.4)
     rake (10.4.2)
     rspec (3.2.0)
       rspec-core (~> 3.2.0)
@@ -63,9 +64,13 @@ DEPENDENCIES
   bump
   mysql2
   parallel!
+  pg
   rake
   rspec
   rspec-legacy_formatters
   rspec-rerun
   ruby-progressbar
   sqlite3
+
+BUNDLED WITH
+   1.11.2

--- a/lib/parallel.rb
+++ b/lib/parallel.rb
@@ -229,12 +229,14 @@ module Parallel
         work_direct(job_factory, options, &block)
       elsif method == :in_threads
         ActiveRecord::Base.connection.disconnect! if ar_workaround
-        work_in_threads(job_factory, options.merge(:count => size), &block)
+        return_value = work_in_threads(job_factory, options.merge(:count => size), &block)
         ActiveRecord::Base.establish_connection if ar_workaround
+        return_value
       else
         ActiveRecord::Base.connection.disconnect! if ar_workaround
-        work_in_processes(job_factory, options.merge(:count => size), &block)
+        return_value = work_in_processes(job_factory, options.merge(:count => size), &block)
         ActiveRecord::Base.establish_connection if ar_workaround
+        return_value
       end
     end
 

--- a/spec/cases/each_with_ar_generic.rb
+++ b/spec/cases/each_with_ar_generic.rb
@@ -26,8 +26,10 @@ puts User.first.name
 # Run with both disabled and enabled Parallel (AR workarounds shouldn't break 0)
 [0,1].each do |zero_one|
   print "Parallel (#{in_worker_type} => #{zero_one}): "
-  Parallel.each([1], in_worker_type => 0) do
-    puts User.all.map(&:name).join
+  Parallel.each([1], in_worker_type => zero_one, reconnect: true) do
+    User.uncached do
+      puts User.all.map(&:name).join
+    end
   end
 end
 

--- a/spec/cases/each_with_ar_generic.rb
+++ b/spec/cases/each_with_ar_generic.rb
@@ -1,0 +1,35 @@
+# Require me in your Database specific case
+
+in_worker_type = "in_#{ENV.fetch('WORKER_TYPE')}".to_sym
+ActiveRecord::Base.establish_connection
+
+class User < ActiveRecord::Base
+end
+
+# create tables
+unless User.table_exists?
+  ActiveRecord::Schema.define(:version => 1) do
+    create_table :users do |t|
+      t.string :name
+    end
+  end
+end
+
+User.delete_all
+
+3.times { User.create!(:name => "X") }
+
+print "Parent: "
+puts User.first.name
+
+
+# Run with both disabled and enabled Parallel (AR workarounds shouldn't break 0)
+[0,1].each do |zero_one|
+  print "Parallel (#{in_worker_type} => #{zero_one}): "
+  Parallel.each([1], in_worker_type => 0) do
+    puts User.all.map(&:name).join
+  end
+end
+
+print "\nParent: "
+puts User.first.name

--- a/spec/cases/each_with_ar_mysql.rb
+++ b/spec/cases/each_with_ar_mysql.rb
@@ -1,11 +1,15 @@
 require './spec/cases/helper'
 require "active_record"
-require "sqlite3"
+require "mysql2"
 STDOUT.sync = true
 in_worker_type = "in_#{ENV.fetch('WORKER_TYPE')}".to_sym
 
+database = "parallel_with_ar_test"
 ActiveRecord::Schema.verbose = false
-ENV["DATABASE_URL"] = "sqlite3:parallel_with_ar_test.sqlite3"
+ENV["DATABASE_URL"] = "mysql2://root@localhost/#{database}"
+
+# Assumes 'root'@'localhost' has no password
+`mysql -u root #{database} -e '' || mysql -u root -e 'create database #{database};'`
 ActiveRecord::Base.establish_connection
 
 class User < ActiveRecord::Base
@@ -38,6 +42,3 @@ end
 
 print "\nParent: "
 puts User.first.name
-
-# Delete the sqlite3 file.  :memory: was neat, but once you disconnect, it's just gone.
-`rm parallel_with_ar_test.sqlite3`

--- a/spec/cases/each_with_ar_mysql.rb
+++ b/spec/cases/each_with_ar_mysql.rb
@@ -2,7 +2,6 @@ require './spec/cases/helper'
 require "active_record"
 require "mysql2"
 STDOUT.sync = true
-in_worker_type = "in_#{ENV.fetch('WORKER_TYPE')}".to_sym
 
 database = "parallel_with_ar_test"
 ActiveRecord::Schema.verbose = false
@@ -10,35 +9,5 @@ ENV["DATABASE_URL"] = "mysql2://root@localhost/#{database}"
 
 # Assumes 'root'@'localhost' has no password
 `mysql -u root #{database} -e '' || mysql -u root -e 'create database #{database};'`
-ActiveRecord::Base.establish_connection
 
-class User < ActiveRecord::Base
-end
-
-# create tables
-unless User.table_exists?
-  ActiveRecord::Schema.define(:version => 1) do
-    create_table :users do |t|
-      t.string :name
-    end
-  end
-end
-
-User.delete_all
-
-3.times { User.create!(:name => "X") }
-
-print "Parent: "
-puts User.first.name
-
-
-# Run with both disabled and enabled Parallel (AR workarounds shouldn't break 0)
-[0,1].each do |zero_one|
-  print "Parallel (#{in_worker_type} => #{zero_one}): "
-  Parallel.each([1], in_worker_type => 0) do
-    puts User.all.map(&:name).join
-  end
-end
-
-print "\nParent: "
-puts User.first.name
+require "./spec/cases/each_with_ar_generic"

--- a/spec/cases/each_with_ar_postgres.rb
+++ b/spec/cases/each_with_ar_postgres.rb
@@ -1,11 +1,15 @@
 require './spec/cases/helper'
 require "active_record"
-require "sqlite3"
+require "pg"
 STDOUT.sync = true
 in_worker_type = "in_#{ENV.fetch('WORKER_TYPE')}".to_sym
 
+database = "parallel_with_ar_test"
 ActiveRecord::Schema.verbose = false
-ENV["DATABASE_URL"] = "sqlite3:parallel_with_ar_test.sqlite3"
+ENV["DATABASE_URL"] = "postgres://postgres@localhost/#{database}"
+
+# Assumes 'postgres' user is SUPERUSER
+`createdb #{database}` unless `psql -l | grep parallel_with_ar_test`
 ActiveRecord::Base.establish_connection
 
 class User < ActiveRecord::Base
@@ -38,6 +42,3 @@ end
 
 print "\nParent: "
 puts User.first.name
-
-# Delete the sqlite3 file.  :memory: was neat, but once you disconnect, it's just gone.
-`rm parallel_with_ar_test.sqlite3`

--- a/spec/cases/each_with_ar_sqlite.rb
+++ b/spec/cases/each_with_ar_sqlite.rb
@@ -2,42 +2,11 @@ require './spec/cases/helper'
 require "active_record"
 require "sqlite3"
 STDOUT.sync = true
-in_worker_type = "in_#{ENV.fetch('WORKER_TYPE')}".to_sym
 
 ActiveRecord::Schema.verbose = false
 ENV["DATABASE_URL"] = "sqlite3:parallel_with_ar_test.sqlite3"
-ActiveRecord::Base.establish_connection
 
-class User < ActiveRecord::Base
-end
-
-# create tables
-unless User.table_exists?
-  ActiveRecord::Schema.define(:version => 1) do
-    create_table :users do |t|
-      t.string :name
-    end
-  end
-end
-
-User.delete_all
-
-3.times { User.create!(:name => "X") }
-
-print "Parent: "
-puts User.first.name
-
-
-# Run with both disabled and enabled Parallel (AR workarounds shouldn't break 0)
-[0,1].each do |zero_one|
-  print "Parallel (#{in_worker_type} => #{zero_one}): "
-  Parallel.each([1], in_worker_type => 0) do
-    puts User.all.map(&:name).join
-  end
-end
-
-print "\nParent: "
-puts User.first.name
+require "./spec/cases/each_with_ar_generic"
 
 # Delete the sqlite3 file.  :memory: was neat, but once you disconnect, it's just gone.
 `rm parallel_with_ar_test.sqlite3`

--- a/spec/cases/each_with_ar_sqlite.rb
+++ b/spec/cases/each_with_ar_sqlite.rb
@@ -5,10 +5,8 @@ STDOUT.sync = true
 in_worker_type = "in_#{ENV.fetch('WORKER_TYPE')}".to_sym
 
 ActiveRecord::Schema.verbose = false
-ActiveRecord::Base.establish_connection(
-  :adapter => "sqlite3",
-  :database => ":memory:"
-)
+params = { adapter: "sqlite3", database: "parallel_with_ar_test.sqlite3" }
+ActiveRecord::Base.establish_connection(params)
 
 class User < ActiveRecord::Base
 end
@@ -29,11 +27,19 @@ User.delete_all
 print "Parent: "
 puts User.first.name
 
+# https://www.sqlite.org/faq.html
+# Under Unix, you should not carry an open SQLite database across a fork() system call into the child process.
+ActiveRecord::Base.connection.disconnect!
+
 print "Parallel (#{in_worker_type}): "
 Parallel.each([1], in_worker_type => 1) do
+  ActiveRecord::Base.establish_connection(params)
   puts User.all.map(&:name).join
 end
 
+ActiveRecord::Base.establish_connection(params)
 print "\nParent: "
 puts User.first.name
 
+# Delete the sqlite3 file.  :memory: was neat, but once you disconnect, it's just gone.
+`rm parallel_with_ar_test.sqlite3`

--- a/spec/parallel_spec.rb
+++ b/spec/parallel_spec.rb
@@ -427,7 +427,7 @@ describe Parallel do
 
     worker_types.each do |type|
       it "works with SQLite in #{type}" do
-        `WORKER_TYPE=#{type} ruby spec/cases/each_with_ar_sqlite.rb`.should == "Parent: X\nParallel (in_#{type}): XXX\n\nParent: X\n"
+        `WORKER_TYPE=#{type} ruby spec/cases/each_with_ar_sqlite.rb 2>&1`.should == "Parent: X\nParallel (in_#{type} => 0): XXX\nParallel (in_#{type} => 1): XXX\n\nParent: X\n"
       end
 
       it "stops all workers when one fails in #{type}" do

--- a/spec/parallel_spec.rb
+++ b/spec/parallel_spec.rb
@@ -426,16 +426,13 @@ describe Parallel do
     end
 
     worker_types.each do |type|
-      it "works with SQLite in #{type}" do
-        `WORKER_TYPE=#{type} ruby spec/cases/each_with_ar_sqlite.rb 2>&1`.should == "Parent: X\nParallel (in_#{type} => 0): XXX\nParallel (in_#{type} => 1): XXX\n\nParent: X\n"
-      end
 
-      it "works with Postgres in #{type}" do
-        `WORKER_TYPE=#{type} ruby spec/cases/each_with_ar_postgres.rb 2>&1`.should == "Parent: X\nParallel (in_#{type} => 0): XXX\nParallel (in_#{type} => 1): XXX\n\nParent: X\n"
-      end
-
-      it "works with MySQL in #{type}" do
-        `WORKER_TYPE=#{type} ruby spec/cases/each_with_ar_mysql.rb 2>&1`.should == "Parent: X\nParallel (in_#{type} => 0): XXX\nParallel (in_#{type} => 1): XXX\n\nParent: X\n"
+      %w(sqlite postgres mysql).each do |db_type|
+        it "works with #{db_type} in #{type}" do
+          result = `WORKER_TYPE=#{type} ruby spec/cases/each_with_ar_#{db_type}.rb 2>&1`
+          pending "#{db_type} test database is not configured" if ["cannot load such file", "ActiveRecord::NoDatabaseError", "Unknown database"].include? result
+          result.should == "Parent: X\nParallel (in_#{type} => 0): XXX\nParallel (in_#{type} => 1): XXX\n\nParent: X\n"
+        end
       end
 
       it "stops all workers when one fails in #{type}" do

--- a/spec/parallel_spec.rb
+++ b/spec/parallel_spec.rb
@@ -430,6 +430,14 @@ describe Parallel do
         `WORKER_TYPE=#{type} ruby spec/cases/each_with_ar_sqlite.rb 2>&1`.should == "Parent: X\nParallel (in_#{type} => 0): XXX\nParallel (in_#{type} => 1): XXX\n\nParent: X\n"
       end
 
+      it "works with Postgres in #{type}" do
+        `WORKER_TYPE=#{type} ruby spec/cases/each_with_ar_postgres.rb 2>&1`.should == "Parent: X\nParallel (in_#{type} => 0): XXX\nParallel (in_#{type} => 1): XXX\n\nParent: X\n"
+      end
+
+      it "works with MySQL in #{type}" do
+        `WORKER_TYPE=#{type} ruby spec/cases/each_with_ar_mysql.rb 2>&1`.should == "Parent: X\nParallel (in_#{type} => 0): XXX\nParallel (in_#{type} => 1): XXX\n\nParent: X\n"
+      end
+
       it "stops all workers when one fails in #{type}" do
         `METHOD=each WORKER_TYPE=#{type} ruby spec/cases/with_exception.rb 2>&1`.should =~ /^\d{4} raised$/
       end

--- a/spec/parallel_spec.rb
+++ b/spec/parallel_spec.rb
@@ -426,7 +426,7 @@ describe Parallel do
     end
 
     worker_types.each do |type|
-      pending "works with SQLite in #{type}" do
+      it "works with SQLite in #{type}" do
         `WORKER_TYPE=#{type} ruby spec/cases/each_with_ar_sqlite.rb`.should == "Parent: X\nParallel (in_#{type}): XXX\n\nParent: X\n"
       end
 


### PR DESCRIPTION
Here's something to take a look at.  I removed the workarounds from the SQLite / MySQL / Postgres tests and added the disconnect / establish_connection calls around the `work_in_threads` and `work_in_processes` calls, but only when ActiveRecord is used.

All specs pass on my computer, but Travis will probably fail since mysql / postgres I imagine won't be setup the same.
I think I can get around that by adding a pending clause in the spec which calls only if the DB isn't found the way it's expected.  Is that how you'd like that handled?  It's so sketchy testing specific databases..

``` bash
rspec --fail-fast
...........................................................................................................

Finished in 2 minutes 20.6 seconds (files took 0.09807 seconds to load)
107 examples, 0 failures
```
