### PR TITLE
expose worker/slot number to tasks via Thread#[]

### DIFF
--- a/lib/parallel.rb
+++ b/lib/parallel.rb
@@ -277,6 +277,7 @@ module Parallel
     end
 
     def work_direct(job_factory, options, &block)
+      Thread.current[:parallel_worker_number] = 0
       results = []
       while set = job_factory.next
         item, index = set
@@ -285,6 +286,8 @@ module Parallel
         end
       end
       results
+    ensure
+      Thread.current[:parallel_worker_number] = nil
     end
 
     def work_in_threads(job_factory, options, &block)

--- a/spec/cases/map_worker_number_isolation.rb
+++ b/spec/cases/map_worker_number_isolation.rb
@@ -2,7 +2,7 @@ require './spec/cases/helper'
 
 process_diff do
   result = Parallel.map([1,2,3,4], in_processes: 2, isolation: true) do |i|
-    Thread.current[:parallel_worker_number]
+    Parallel.worker_number
   end
   puts result.uniq.sort.join(',')
 end

--- a/spec/cases/map_worker_number_isolation.rb
+++ b/spec/cases/map_worker_number_isolation.rb
@@ -1,0 +1,8 @@
+require './spec/cases/helper'
+
+process_diff do
+  result = Parallel.map([1,2,3,4], in_processes: 2, isolation: true) do |i|
+    Thread.current[:parallel_worker_number]
+  end
+  puts result.uniq.sort.join(',')
+end

--- a/spec/cases/with_worker_number.rb
+++ b/spec/cases/with_worker_number.rb
@@ -1,0 +1,11 @@
+require './spec/cases/helper'
+
+method = ENV.fetch('METHOD')
+in_worker_type = "in_#{ENV.fetch('WORKER_TYPE')}".to_sym
+
+result = Parallel.public_send(method, 1..100, in_worker_type => 4) do
+  sleep 0.1 # so all workers get started
+  print Thread.current[:parallel_worker_number]
+  nil
+end
+

--- a/spec/cases/with_worker_number.rb
+++ b/spec/cases/with_worker_number.rb
@@ -5,6 +5,6 @@ in_worker_type = "in_#{ENV.fetch('WORKER_TYPE')}".to_sym
 
 Parallel.public_send(method, 1..100, in_worker_type => 4) do
   sleep 0.1 # so all workers get started
-  print Thread.current[:parallel_worker_number]
+  print Parallel.worker_number
 end
 

--- a/spec/cases/with_worker_number.rb
+++ b/spec/cases/with_worker_number.rb
@@ -3,9 +3,8 @@ require './spec/cases/helper'
 method = ENV.fetch('METHOD')
 in_worker_type = "in_#{ENV.fetch('WORKER_TYPE')}".to_sym
 
-result = Parallel.public_send(method, 1..100, in_worker_type => 4) do
+Parallel.public_send(method, 1..100, in_worker_type => 4) do
   sleep 0.1 # so all workers get started
   print Thread.current[:parallel_worker_number]
-  nil
 end
 

--- a/spec/parallel_spec.rb
+++ b/spec/parallel_spec.rb
@@ -262,7 +262,7 @@ describe Parallel do
       end
 
       it "sets Parallel.worker_number with 4 #{type}" do
-        out = `METHOD=map WORKER_TYPE=#{type} ruby spec/cases/with_worker_number.rb`
+        out = `METHOD=map WORKER_TYPE=#{type} ruby spec/cases/with_worker_number.rb 2>&1`
         out.should =~ /\A[0123]+\z/
         %w(0 1 2 3).each { |number| out.should include number }
       end
@@ -482,7 +482,7 @@ describe Parallel do
       end
 
       it "sets Parallel.worker_number with #{type}" do
-        out = `METHOD=each WORKER_TYPE=#{type} ruby spec/cases/with_worker_number.rb`
+        out = `METHOD=each WORKER_TYPE=#{type} ruby spec/cases/with_worker_number.rb 2>&1`
         out.should =~ /\A[0123]+\z/
         %w(0 1 2 3).each { |number| out.should include number }
       end

--- a/spec/parallel_spec.rb
+++ b/spec/parallel_spec.rb
@@ -261,16 +261,16 @@ describe Parallel do
         `METHOD=map WORKER_TYPE=#{type} ruby spec/cases/with_exception_in_start_before_finish.rb 2>&1`.should == '3 called'
       end
 
-      it "has access to thread local parallel_worker_number with 4 #{type}" do
+      it "sets Parallel.worker_number with 4 #{type}" do
         out = `METHOD=map WORKER_TYPE=#{type} ruby spec/cases/with_worker_number.rb`
         out.should =~ /\A[0123]+\z/
         %w(0 1 2 3).each { |number| out.should include number }
       end
 
-      it "has access to thread local parallel_worker_number with 0 #{type}" do
+      it "sets Parallel.worker_number with 0 #{type}" do
         type_key = "in_#{type}".to_sym
-        Parallel.map([1,2,3,4,5,6,7,8,9], type_key => 0) { |x| Thread.current[:parallel_worker_number] }.uniq.should == [0]
-        Thread.current[:parallel_worker_number].should be_nil
+        Parallel.map([1,2,3,4,5,6,7,8,9], type_key => 0) { |x| Parallel.worker_number }.uniq.should == [0]
+        Parallel.worker_number.should be_nil
       end
     end
 
@@ -388,7 +388,7 @@ describe Parallel do
       out.should == "1\n2\n3\n4\nOK"
     end
 
-    it 'has access to thread local parallel_worker_number values in isolation' do
+    it 'sets Parallel.worker_number when run with isolation' do
       out = `ruby spec/cases/map_worker_number_isolation.rb`
       out.should == "0,1\nOK"
     end
@@ -481,7 +481,7 @@ describe Parallel do
         `METHOD=each WORKER_TYPE=#{type} ruby spec/cases/with_exception_in_start_before_finish.rb 2>&1`.should == '3 called'
       end
 
-      it "has access to thread local parallel_worker_number with #{type}" do
+      it "sets Parallel.worker_number with #{type}" do
         out = `METHOD=each WORKER_TYPE=#{type} ruby spec/cases/with_worker_number.rb`
         out.should =~ /\A[0123]+\z/
         %w(0 1 2 3).each { |number| out.should include number }

--- a/spec/parallel_spec.rb
+++ b/spec/parallel_spec.rb
@@ -260,6 +260,12 @@ describe Parallel do
       it "does not call the finish hook when a start hook fails with #{type}" do
         `METHOD=map WORKER_TYPE=#{type} ruby spec/cases/with_exception_in_start_before_finish.rb 2>&1`.should == '3 called'
       end
+
+      it "has access to thread local parallel_worker_number with #{type}" do
+        out = `METHOD=map WORKER_TYPE=#{type} ruby spec/cases/with_worker_number.rb`
+        out.should =~ /\A[0123]+\z/
+        %w(0 1 2 3).each { |number| out.should include number }
+      end
     end
 
     it "can run with 0 threads" do
@@ -375,6 +381,12 @@ describe Parallel do
       out = `ruby spec/cases/map_isolation.rb`
       out.should == "1\n2\n3\n4\nOK"
     end
+
+    it 'has access to thread local parallel_worker_number values in isolation' do
+      out = `ruby spec/cases/map_worker_number_isolation.rb`
+      out.should == "0,1\nOK"
+    end
+
   end
 
   describe ".map_with_index" do
@@ -461,6 +473,12 @@ describe Parallel do
 
       it "does not call the finish hook when a start hook fails with #{type}" do
         `METHOD=each WORKER_TYPE=#{type} ruby spec/cases/with_exception_in_start_before_finish.rb 2>&1`.should == '3 called'
+      end
+
+      it "has access to thread local parallel_worker_number with #{type}" do
+        out = `METHOD=each WORKER_TYPE=#{type} ruby spec/cases/with_worker_number.rb`
+        out.should =~ /\A[0123]+\z/
+        %w(0 1 2 3).each { |number| out.should include number }
       end
     end
   end

--- a/spec/parallel_spec.rb
+++ b/spec/parallel_spec.rb
@@ -261,10 +261,16 @@ describe Parallel do
         `METHOD=map WORKER_TYPE=#{type} ruby spec/cases/with_exception_in_start_before_finish.rb 2>&1`.should == '3 called'
       end
 
-      it "has access to thread local parallel_worker_number with #{type}" do
+      it "has access to thread local parallel_worker_number with 4 #{type}" do
         out = `METHOD=map WORKER_TYPE=#{type} ruby spec/cases/with_worker_number.rb`
         out.should =~ /\A[0123]+\z/
         %w(0 1 2 3).each { |number| out.should include number }
+      end
+
+      it "has access to thread local parallel_worker_number with 0 #{type}" do
+        type_key = "in_#{type}".to_sym
+        Parallel.map([1,2,3,4,5,6,7,8,9], type_key => 0) { |x| Thread.current[:parallel_worker_number] }.uniq.should == [0]
+        Thread.current[:parallel_worker_number].should be_nil
       end
     end
 


### PR DESCRIPTION
When processing tasks, set a thread local value `:parallel_worker_number` to allow the task logic to know what 'slot' it is in, so that parallel tasks can coordinate access to external resources like database schemas -- basically for the same purposes as the TEST_ENV_NUMBER environment variable in the [parallel_tests](https://github.com/grosser/parallel_tests) gem.