### PR TITLE
add option[:exit_bang_status] so child does exit!() when ending

### DIFF
--- a/lib/parallel.rb
+++ b/lib/parallel.rb
@@ -405,7 +405,9 @@ module Parallel
         ensure
           child_read.close
           child_write.close
+          exit!(options[:exit_bang_status]) unless options[:exit_bang_status].nil?
         end
+
       end
 
       child_read.close


### PR DESCRIPTION
Mitigates child workers from closing inherited connections upon exit. In particular for mysql connections owned by the parent rails app would be inadvertently closed by the child when exiting normally and result in this error for subsequent queries in the parent: "ActiveRecord::StatementInvalid: Mysql2::Error: MySQL server has gone away"