### PR TITLE
Do not call kill method if thread is nil

### DIFF
--- a/lib/parallel.rb
+++ b/lib/parallel.rb
@@ -355,7 +355,7 @@ module Parallel
                 exception = e
                 if Parallel::Kill === exception
                   (workers - [worker]).each do |w|
-                    w.thread.kill
+                    w.thread.kill unless w.thread.nil?
                     UserInterruptHandler.kill(w.pid)
                   end
                 end


### PR DESCRIPTION
Hi,

Parallel 1.9 seems to have a race condition of some kind around Parallel::Kill, which can intermittently cause the following error:

```
    undefined method `kill' for nil:NilClass
     # ./vendor/bundle/ruby/2.1.0/gems/parallel-1.9.0/lib/parallel.rb:358:in `block (4 levels) in work_in_processes'
     # ./vendor/bundle/ruby/2.1.0/gems/parallel-1.9.0/lib/parallel.rb:357:in `each'
     # ./vendor/bundle/ruby/2.1.0/gems/parallel-1.9.0/lib/parallel.rb:357:in `rescue in block (3 levels) in work_in_processes'
     # ./vendor/bundle/ruby/2.1.0/gems/parallel-1.9.0/lib/parallel.rb:349:in `block (3 levels) in work_in_processes'
     # ./vendor/bundle/ruby/2.1.0/gems/parallel-1.9.0/lib/parallel.rb:338:in `loop'
     # ./vendor/bundle/ruby/2.1.0/gems/parallel-1.9.0/lib/parallel.rb:338:in `block (2 levels) in work_in_processes'
     # ./vendor/bundle/ruby/2.1.0/gems/parallel-1.9.0/lib/parallel.rb:192:in `block (2 levels) in in_threads'
     # ------------------
     # --- Caused by: ---
     # Parallel::Kill:
     #   Parallel::Kill
```

I observed this under Ruby 2.1, 2.2, and 2.3. I've created a simple check that w.thread is not nil before killing it and this seems to solve the problem for me.