### PR TITLE
Simplify Array initialization with slight performance improvement

### DIFF
--- a/lib/parallel.rb
+++ b/lib/parallel.rb
@@ -199,7 +199,7 @@ module Parallel
   class << self
     def in_threads(options={:count => 2})
       count, _ = extract_count_from_options(options)
-      Array.new(count).each_with_index.map do |_, i|
+      Array.new(count) do |i|
         Thread.new { yield(i) }
       end.map!(&:value)
     end


### PR DESCRIPTION
I would like to simplify Array initialization by using `new(size) {|index| block }`.
http://ruby-doc.org/core-2.4.0/Array.html#method-c-new

This patch also slightly improves the performance of Array initialization.