### PR TITLE
Fixes crash on Kill and Break when the better_errors gem is being used

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -69,6 +69,3 @@ DEPENDENCIES
   rspec-rerun
   ruby-progressbar
   sqlite3
-
-BUNDLED WITH
-   1.13.6

--- a/lib/parallel.rb
+++ b/lib/parallel.rb
@@ -15,13 +15,10 @@ module Parallel
   end
 
   class UndumpableException < StandardError
+    attr_reader :backtrace
     def initialize(original)
       super "#{original.class}: #{original.message}"
-      @bracktrace = original.backtrace
-    end
-
-    def backtrace
-      @bracktrace
+      @backtrace = original.backtrace
     end
   end
 

--- a/lib/parallel.rb
+++ b/lib/parallel.rb
@@ -27,6 +27,12 @@ module Parallel
   class ExceptionWrapper
     attr_reader :exception
     def initialize(exception)
+      # Remove the bindings stack added by the better_errors gem,
+      # because it cannot be marshalled
+      if exception.instance_variable_defined? :@__better_errors_bindings_stack
+        exception.send :remove_instance_variable, :@__better_errors_bindings_stack
+      end
+
       @exception =
         begin
           Marshal.dump(exception) && exception

--- a/spec/cases/parallel_break_better_errors.rb
+++ b/spec/cases/parallel_break_better_errors.rb
@@ -1,0 +1,21 @@
+require './spec/cases/helper'
+require 'stringio'
+
+class MyException < StandardError
+  def initialize(object)
+    @object = object
+  end
+end
+
+begin
+  Parallel.in_processes(2) do
+    ex = Parallel::Break.new
+    # better_errors sets an instance variable that contains an array of bindings.
+    ex.instance_variable_set :@__better_errors_bindings_stack, [ex.send(:binding)]
+    raise ex
+  end
+  puts "NOTHING WAS RAISED"
+rescue
+  puts $!.message
+  puts "BACKTRACE: #{$!.backtrace.first}"
+end

--- a/spec/parallel_spec.rb
+++ b/spec/parallel_spec.rb
@@ -160,6 +160,11 @@ describe Parallel do
       out.should == "MyException: MyException\nBACKTRACE: spec/cases/parallel_raise_undumpable.rb:12"
     end
 
+    it "can handle Break exceptions when the better_errors gem is installed" do
+      out = `ruby spec/cases/parallel_break_better_errors.rb`.strip
+      out.should == "NOTHING WAS RAISED"
+    end
+
     it 'can handle to high fork rate' do
       unless RbConfig::CONFIG["target_os"] =~ /darwin1/
         `ruby spec/cases/parallel_high_fork_rate.rb`.should == 'OK'


### PR DESCRIPTION
I use the [better_errors](https://github.com/charliesome/better_errors) gem with Rails, which ends up [making exceptions undumpable](https://github.com/charliesome/better_errors/issues/254). This includes `Parallel::Break` and `Parallel::Kill`. When debugging `ExceptionWrapper#initialize` in the Rails console, I was seeing this error:

```Ruby
TypeError - no _dump_data is defined for class Binding:
```

This commit changes `ExceptionWrapper` to return empty `Break` or `Kill` exceptions (by calling `exception.class.new`. It fixes the undumpable exception issue, and also provides the tiniest of performance improvements, because we don't need to marshall the backtrace.

(I'll push two commits separately. First the failing test, then the fix.)