### PR TITLE
Fix #149 - Utilize Etc.nprocessors in Ruby 2.2+

### DIFF
--- a/lib/parallel/processor_count.rb
+++ b/lib/parallel/processor_count.rb
@@ -1,3 +1,7 @@
+if RUBY_VERSION.to_f >= 2.2
+  require 'etc'
+end
+
 module Parallel
   module ProcessorCount
     # Number of processors seen by the OS and used for process scheduling.
@@ -16,36 +20,40 @@ module Parallel
     #
     def processor_count
       @processor_count ||= begin
-        os_name = RbConfig::CONFIG["target_os"]
-        if os_name =~ /mingw|mswin/
-          require 'win32ole'
-          result = WIN32OLE.connect("winmgmts://").ExecQuery(
-            "select NumberOfLogicalProcessors from Win32_Processor")
-          result.to_enum.collect(&:NumberOfLogicalProcessors).reduce(:+)
-        elsif File.readable?("/proc/cpuinfo")
-          IO.read("/proc/cpuinfo").scan(/^processor/).size
-        elsif File.executable?("/usr/bin/hwprefs")
-          IO.popen("/usr/bin/hwprefs thread_count").read.to_i
-        elsif File.executable?("/usr/sbin/psrinfo")
-          IO.popen("/usr/sbin/psrinfo").read.scan(/^.*on-*line/).size
-        elsif File.executable?("/usr/sbin/ioscan")
-          IO.popen("/usr/sbin/ioscan -kC processor") do |out|
-            out.read.scan(/^.*processor/).size
-          end
-        elsif File.executable?("/usr/sbin/pmcycles")
-          IO.popen("/usr/sbin/pmcycles -m").read.count("\n")
-        elsif File.executable?("/usr/sbin/lsdev")
-          IO.popen("/usr/sbin/lsdev -Cc processor -S 1").read.count("\n")
-        elsif File.executable?("/usr/sbin/sysconf") and os_name =~ /irix/i
-          IO.popen("/usr/sbin/sysconf NPROC_ONLN").read.to_i
-        elsif File.executable?("/usr/sbin/sysctl")
-          IO.popen("/usr/sbin/sysctl -n hw.ncpu").read.to_i
-        elsif File.executable?("/sbin/sysctl")
-          IO.popen("/sbin/sysctl -n hw.ncpu").read.to_i
+        if defined?(Etc)
+          Etc.nprocessors
         else
-          $stderr.puts "Unknown platform: " + RbConfig::CONFIG["target_os"]
-          $stderr.puts "Assuming 1 processor."
-          1
+          os_name = RbConfig::CONFIG["target_os"]
+          if os_name =~ /mingw|mswin/
+            require 'win32ole'
+            result = WIN32OLE.connect("winmgmts://").ExecQuery(
+              "select NumberOfLogicalProcessors from Win32_Processor")
+            result.to_enum.collect(&:NumberOfLogicalProcessors).reduce(:+)
+          elsif File.readable?("/proc/cpuinfo")
+            IO.read("/proc/cpuinfo").scan(/^processor/).size
+          elsif File.executable?("/usr/bin/hwprefs")
+            IO.popen("/usr/bin/hwprefs thread_count").read.to_i
+          elsif File.executable?("/usr/sbin/psrinfo")
+            IO.popen("/usr/sbin/psrinfo").read.scan(/^.*on-*line/).size
+          elsif File.executable?("/usr/sbin/ioscan")
+            IO.popen("/usr/sbin/ioscan -kC processor") do |out|
+              out.read.scan(/^.*processor/).size
+            end
+          elsif File.executable?("/usr/sbin/pmcycles")
+            IO.popen("/usr/sbin/pmcycles -m").read.count("\n")
+          elsif File.executable?("/usr/sbin/lsdev")
+            IO.popen("/usr/sbin/lsdev -Cc processor -S 1").read.count("\n")
+          elsif File.executable?("/usr/sbin/sysconf") and os_name =~ /irix/i
+            IO.popen("/usr/sbin/sysconf NPROC_ONLN").read.to_i
+          elsif File.executable?("/usr/sbin/sysctl")
+            IO.popen("/usr/sbin/sysctl -n hw.ncpu").read.to_i
+          elsif File.executable?("/sbin/sysctl")
+            IO.popen("/sbin/sysctl -n hw.ncpu").read.to_i
+          else
+            $stderr.puts "Unknown platform: " + RbConfig::CONFIG["target_os"]
+            $stderr.puts "Assuming 1 processor."
+            1
+          end
         end
       end
     end

--- a/lib/parallel/processor_count.rb
+++ b/lib/parallel/processor_count.rb
@@ -20,7 +20,7 @@ module Parallel
     #
     def processor_count
       @processor_count ||= begin
-        if defined?(Etc)
+        if defined?(Etc) && Etc.respond_to?(:nprocessors)
           Etc.nprocessors
         else
           os_name = RbConfig::CONFIG["target_os"]

--- a/spec/parallel_spec.rb
+++ b/spec/parallel_spec.rb
@@ -50,7 +50,7 @@ describe Parallel do
       end
     else
       it 'doesnt use Etc.nprocessors in Ruby 2.1 and below' do
-        defined?(Etc).should == nil
+        defined?(Etc).should == "constant"
       end
     end
   end

--- a/spec/parallel_spec.rb
+++ b/spec/parallel_spec.rb
@@ -42,6 +42,17 @@ describe Parallel do
         (1..999).should include(Parallel.processor_count)
       end
     end
+
+    if RUBY_VERSION.to_f >= 2.2
+      it 'uses Etc.nprocessors in Ruby 2.2+' do
+        defined?(Etc).should == "constant" 
+        Etc.respond_to?(:nprocessors).should == true 
+      end
+    else
+      it 'doesnt use Etc.nprocessors in Ruby 2.1 and below' do
+        defined?(Etc).should == nil
+      end
+    end
   end
 
   describe ".physical_processor_count" do


### PR DESCRIPTION
Fixes #149