### PR TITLE
Within the Interrupt Signal handler, ensure the trapped signal is callable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: ruby
 cache: bundler
 sudo: false
+dist: precise
 branches:
   only: master
 rvm:

--- a/lib/parallel.rb
+++ b/lib/parallel.rb
@@ -183,7 +183,7 @@ module Parallel
 
         Signal.trap signal do
           yield
-          if old == "DEFAULT"
+          if old == "DEFAULT" || !old.respond_to?(:call)
             raise Interrupt
           else
             old.call

--- a/lib/parallel.rb
+++ b/lib/parallel.rb
@@ -183,7 +183,7 @@ module Parallel
 
         Signal.trap signal do
           yield
-          if old == "DEFAULT" || !old.respond_to?(:call)
+          if !old || old == "DEFAULT"
             raise Interrupt
           else
             old.call


### PR DESCRIPTION
I added a check within the `trap_interrupt` method to ensure that the trapped signal is in-fact callable.  I'm running into the situation where a CTRL-C within a Parallel block doing heavy database work will cause this:

```
undefined method `call' for nil:NilClass
```

It's the `old.call` tripping things up.  With this change if there's a problem trapping the signal it will default to the ruby default handler behavior of just re-raising Interrupt.  I tried building a Micky Mouse example but unless I'm waist deep in my Oracle to MySQL ETL it traps the signal just fine.


```
/Users/duffyjp/.rvm/gems/ruby-2.3.5/gems/parallel-1.12.0/lib/parallel.rb:189:in `block in trap_interrupt'
/Users/duffyjp/.rvm/gems/ruby-2.3.5/gems/parallel-1.12.0/lib/parallel.rb:207:in `value'
/Users/duffyjp/.rvm/gems/ruby-2.3.5/gems/parallel-1.12.0/lib/parallel.rb:207:in `map!'
/Users/duffyjp/.rvm/gems/ruby-2.3.5/gems/parallel-1.12.0/lib/parallel.rb:207:in `in_threads'
/Users/duffyjp/.rvm/gems/ruby-2.3.5/gems/parallel-1.12.0/lib/parallel.rb:365:in `block in work_in_processes'
/Users/duffyjp/.rvm/gems/ruby-2.3.5/gems/parallel-1.12.0/lib/parallel.rb:166:in `kill_on_ctrl_c'
/Users/duffyjp/.rvm/gems/ruby-2.3.5/gems/parallel-1.12.0/lib/parallel.rb:364:in `work_in_processes'
/Users/duffyjp/.rvm/gems/ruby-2.3.5/gems/parallel-1.12.0/lib/parallel.rb:264:in `map'
/Users/duffyjp/.rvm/gems/ruby-2.3.5/gems/parallel-1.12.0/lib/parallel.rb:217:in `each'
/Users/duffyjp/Rails/pims/lib/tasks/import/hrs_jobs.rake:10:in `block (2 levels) in <top (required)>'
/Users/duffyjp/.rvm/gems/ruby-2.3.5/gems/rake-12.1.0/lib/rake/task.rb:251:in `block in execute'
/Users/duffyjp/.rvm/gems/ruby-2.3.5/gems/rake-12.1.0/lib/rake/task.rb:251:in `each'
/Users/duffyjp/.rvm/gems/ruby-2.3.5/gems/rake-12.1.0/lib/rake/task.rb:251:in `execute'
/Users/duffyjp/.rvm/gems/ruby-2.3.5/gems/rake-12.1.0/lib/rake/task.rb:195:in `block in invoke_with_call_chain'
/Users/duffyjp/.rvm/rubies/ruby-2.3.5/lib/ruby/2.3.0/monitor.rb:214:in `mon_synchronize'
/Users/duffyjp/.rvm/gems/ruby-2.3.5/gems/rake-12.1.0/lib/rake/task.rb:188:in `invoke_with_call_chain'
/Users/duffyjp/.rvm/gems/ruby-2.3.5/gems/rake-12.1.0/lib/rake/task.rb:181:in `invoke'
/Users/duffyjp/.rvm/gems/ruby-2.3.5/gems/rake-12.1.0/lib/rake/application.rb:153:in `invoke_task'
/Users/duffyjp/.rvm/gems/ruby-2.3.5/gems/rake-12.1.0/lib/rake/application.rb:109:in `block (2 levels) in top_level'
/Users/duffyjp/.rvm/gems/ruby-2.3.5/gems/rake-12.1.0/lib/rake/application.rb:109:in `each'
/Users/duffyjp/.rvm/gems/ruby-2.3.5/gems/rake-12.1.0/lib/rake/application.rb:109:in `block in top_level'
/Users/duffyjp/.rvm/gems/ruby-2.3.5/gems/rake-12.1.0/lib/rake/application.rb:118:in `run_with_threads'
/Users/duffyjp/.rvm/gems/ruby-2.3.5/gems/rake-12.1.0/lib/rake/application.rb:103:in `top_level'
/Users/duffyjp/.rvm/gems/ruby-2.3.5/gems/rake-12.1.0/lib/rake/application.rb:81:in `block in run'
/Users/duffyjp/.rvm/gems/ruby-2.3.5/gems/rake-12.1.0/lib/rake/application.rb:179:in `standard_exception_handling'
/Users/duffyjp/.rvm/gems/ruby-2.3.5/gems/rake-12.1.0/lib/rake/application.rb:78:in `run'
/Users/duffyjp/.rvm/gems/ruby-2.3.5/gems/rake-12.1.0/exe/rake:27:in `<top (required)>'
/Users/duffyjp/.rvm/gems/ruby-2.3.5/bin/rake:23:in `load'
/Users/duffyjp/.rvm/gems/ruby-2.3.5/bin/rake:23:in `<main>'
/Users/duffyjp/.rvm/gems/ruby-2.3.5/bin/ruby_executable_hooks:15:in `eval'
/Users/duffyjp/.rvm/gems/ruby-2.3.5/bin/ruby_executable_hooks:15:in `<main>'
```