### PR TITLE
Add ProgressBar dependency

### DIFF
--- a/parallel.gemspec
+++ b/parallel.gemspec
@@ -10,4 +10,6 @@ Gem::Specification.new name, Parallel::VERSION do |s|
   s.files = `git ls-files lib MIT-LICENSE.txt`.split("\n")
   s.license = "MIT"
   s.required_ruby_version = '>= 1.9.3'
+  
+  s.add_runtime_dependency('progressbar')
 end


### PR DESCRIPTION
When using this gem via Bundler, using the `progress` option results in this error:

    LoadError: cannot load such file -- ruby-progressbar

This PR adds the dependency so that the progressbar gem will be installed along with parallel.