### PR TITLE
only check for our processes

### DIFF
--- a/spec/cases/helper.rb
+++ b/spec/cases/helper.rb
@@ -2,7 +2,7 @@ require 'bundler/setup'
 require 'parallel'
 
 def process_diff
-  cmd = "ps uaxw|grep ruby|wc -l"
+  cmd = "ps uxw|grep ruby|wc -l"
 
   processes_before = `#{cmd}`.to_i
 


### PR DESCRIPTION
by @simcha
I got no errors on my local run and travis got different errors on my copy of same tree:
https://travis-ci.org/simcha/parallel/builds/168296730.
It seams to be error related to process_diff method
And especially command "ps uaxw|grep ruby|wc -l"
It is not checking only our processes and sometime can result with error.