### PR TITLE
Drop ruby support under 2.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ dist: precise
 branches:
   only: master
 rvm:
+  - 2.2
   - 2.3
   - 2.4
   - 2.5

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,6 @@ dist: precise
 branches:
   only: master
 rvm:
-  - 1.9
-  - 2.0
-  - 2.1
-  - 2.2
   - 2.3
   - 2.4
   - 2.5

--- a/lib/parallel/processor_count.rb
+++ b/lib/parallel/processor_count.rb
@@ -1,60 +1,11 @@
-if RUBY_VERSION.to_f >= 2.2
-  require 'etc'
-end
+require 'etc'
 
 module Parallel
   module ProcessorCount
-    # Number of processors seen by the OS and used for process scheduling.
-    #
-    # * AIX: /usr/sbin/pmcycles (AIX 5+), /usr/sbin/lsdev
-    # * BSD: /sbin/sysctl
-    # * Cygwin: /proc/cpuinfo
-    # * Darwin: /usr/bin/hwprefs, /usr/sbin/sysctl
-    # * HP-UX: /usr/sbin/ioscan
-    # * IRIX: /usr/sbin/sysconf
-    # * Linux: /proc/cpuinfo
-    # * Minix 3+: /proc/cpuinfo
-    # * Solaris: /usr/sbin/psrinfo
-    # * Tru64 UNIX: /usr/sbin/psrinfo
-    # * UnixWare: /usr/sbin/psrinfo
-    #
+    # Number of processors seen by the OS and used for process scheduling. It's just wrapper for Etc.nprocessors
     def processor_count
       @processor_count ||= begin
-        if defined?(Etc) && Etc.respond_to?(:nprocessors)
-          Etc.nprocessors
-        else
-          os_name = RbConfig::CONFIG["target_os"]
-          if os_name =~ /mingw|mswin/
-            require 'win32ole'
-            result = WIN32OLE.connect("winmgmts://").ExecQuery(
-              "select NumberOfLogicalProcessors from Win32_Processor")
-            result.to_enum.collect(&:NumberOfLogicalProcessors).reduce(:+)
-          elsif File.readable?("/proc/cpuinfo")
-            IO.read("/proc/cpuinfo").scan(/^processor/).size
-          elsif File.executable?("/usr/bin/hwprefs")
-            IO.popen("/usr/bin/hwprefs thread_count").read.to_i
-          elsif File.executable?("/usr/sbin/psrinfo")
-            IO.popen("/usr/sbin/psrinfo").read.scan(/^.*on-*line/).size
-          elsif File.executable?("/usr/sbin/ioscan")
-            IO.popen("/usr/sbin/ioscan -kC processor") do |out|
-              out.read.scan(/^.*processor/).size
-            end
-          elsif File.executable?("/usr/sbin/pmcycles")
-            IO.popen("/usr/sbin/pmcycles -m").read.count("\n")
-          elsif File.executable?("/usr/sbin/lsdev")
-            IO.popen("/usr/sbin/lsdev -Cc processor -S 1").read.count("\n")
-          elsif File.executable?("/usr/sbin/sysconf") and os_name =~ /irix/i
-            IO.popen("/usr/sbin/sysconf NPROC_ONLN").read.to_i
-          elsif File.executable?("/usr/sbin/sysctl")
-            IO.popen("/usr/sbin/sysctl -n hw.ncpu").read.to_i
-          elsif File.executable?("/sbin/sysctl")
-            IO.popen("/sbin/sysctl -n hw.ncpu").read.to_i
-          else
-            $stderr.puts "Unknown platform: " + RbConfig::CONFIG["target_os"]
-            $stderr.puts "Assuming 1 processor."
-            1
-          end
-        end
+        Etc.nprocessors
       end
     end
 

--- a/parallel.gemspec
+++ b/parallel.gemspec
@@ -9,5 +9,5 @@ Gem::Specification.new name, Parallel::VERSION do |s|
   s.homepage = "https://github.com/grosser/#{name}"
   s.files = `git ls-files lib MIT-LICENSE.txt`.split("\n")
   s.license = "MIT"
-  s.required_ruby_version = '>= 1.9.3'
+  s.required_ruby_version = '>= 2.3'
 end

--- a/parallel.gemspec
+++ b/parallel.gemspec
@@ -9,5 +9,5 @@ Gem::Specification.new name, Parallel::VERSION do |s|
   s.homepage = "https://github.com/grosser/#{name}"
   s.files = `git ls-files lib MIT-LICENSE.txt`.split("\n")
   s.license = "MIT"
-  s.required_ruby_version = '>= 2.3'
+  s.required_ruby_version = '>= 2.2'
 end

--- a/spec/parallel_spec.rb
+++ b/spec/parallel_spec.rb
@@ -43,15 +43,9 @@ describe Parallel do
       end
     end
 
-    if RUBY_VERSION.to_f >= 2.2
-      it 'uses Etc.nprocessors in Ruby 2.2+' do
-        defined?(Etc).should == "constant"
-        Etc.respond_to?(:nprocessors).should == true
-      end
-    else
-      it 'doesnt use Etc.nprocessors in Ruby 2.1 and below' do
-        defined?(Etc).should == "constant"
-      end
+    it 'uses Etc.nprocessors in Ruby 2.2+' do
+      defined?(Etc).should == "constant"
+      Etc.respond_to?(:nprocessors).should == true
     end
   end
 


### PR DESCRIPTION
https://www.ruby-lang.org/en/downloads/branches/

Ruby 2.2 was already EOL before about a year. And many libraries drop support it.

I'm trying to build development environment of this project on my machine.
But It's hard because  Gemfile.lock libraries is too old.
I'll try to update libraries before drop ruby support, but It's hard. So I try to drop old ruby version.

If this procject can drop old ruby support, I'll try to update Gemfile.lock dependencies.
