### PR TITLE
update mysql2 on Gemfile.lock

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -24,7 +24,7 @@ GEM
     diff-lcs (1.3)
     i18n (0.8.1)
     minitest (5.10.1)
-    mysql2 (0.4.6)
+    mysql2 (0.5.2)
     rake (12.0.0)
     rspec (3.6.0)
       rspec-core (~> 3.6.0)
@@ -67,4 +67,4 @@ DEPENDENCIES
   sqlite3
 
 BUNDLED WITH
-   1.16.1
+   1.17.2


### PR DESCRIPTION
bundle install failed with mysql8

mysql2 support this since v0.5.0 https://github.com/brianmario/mysql2/releases/tag/0.5.0

```
    current directory: /Users/yoshimin/.rbenv/versions/2.6.1/lib/ruby/gems/2.6.0/gems/mysql2-0.4.6/ext/mysql2
/Users/yoshimin/.rbenv/versions/2.6.1/bin/ruby -I /Users/yoshimin/.rbenv/versions/2.6.1/lib/ruby/2.6.0 -r
./siteconf20190223-68495-1v8oltr.rb extconf.rb
checking for rb_absint_size()... yes
checking for rb_absint_singlebit_p()... yes
checking for ruby/thread.h... yes
checking for rb_thread_call_without_gvl() in ruby/thread.h... yes
checking for rb_thread_blocking_region()... no
checking for rb_wait_for_single_fd()... yes
checking for rb_hash_dup()... yes
checking for rb_intern3()... yes
checking for rb_big_cmp()... yes
-----
Using mysql_config at /usr/local/bin/mysql_config
-----
checking for mysql.h... yes
checking for SSL_MODE_DISABLED in mysql.h... yes
checking for SSL_MODE_PREFERRED in mysql.h... yes
checking for SSL_MODE_REQUIRED in mysql.h... yes
checking for SSL_MODE_VERIFY_CA in mysql.h... yes
checking for SSL_MODE_VERIFY_IDENTITY in mysql.h... yes
checking for errmsg.h... yes
checking for mysqld_error.h... yes
-----
Don't know how to set rpath on your system, if MySQL libraries are not in path mysql2 may not load
-----
-----
Setting libpath to /usr/local/Cellar/mysql/8.0.12/lib
-----
creating Makefile

current directory: /Users/yoshimin/.rbenv/versions/2.6.1/lib/ruby/gems/2.6.0/gems/mysql2-0.4.6/ext/mysql2
make "DESTDIR=" clean

current directory: /Users/yoshimin/.rbenv/versions/2.6.1/lib/ruby/gems/2.6.0/gems/mysql2-0.4.6/ext/mysql2
make "DESTDIR="
compiling client.c
client.c:869:10: error: use of undeclared identifier 'MYSQL_SECURE_AUTH'; did you mean 'MYSQL_DEFAULT_AUTH'?
    case MYSQL_SECURE_AUTH:
         ^~~~~~~~~~~~~~~~~
         MYSQL_DEFAULT_AUTH
/usr/local/Cellar/mysql/8.0.12/include/mysql/mysql.h:188:3: note: 'MYSQL_DEFAULT_AUTH' declared here
  MYSQL_DEFAULT_AUTH,
  ^
client.c:1291:38: error: use of undeclared identifier 'MYSQL_SECURE_AUTH'; did you mean 'MYSQL_DEFAULT_AUTH'?
  return _mysql_client_options(self, MYSQL_SECURE_AUTH, value);
                                     ^~~~~~~~~~~~~~~~~
                                     MYSQL_DEFAULT_AUTH
/usr/local/Cellar/mysql/8.0.12/include/mysql/mysql.h:188:3: note: 'MYSQL_DEFAULT_AUTH' declared here
  MYSQL_DEFAULT_AUTH,
  ^
2 errors generated.
make: *** [client.o] Error 1

make failed, exit code 2
```