### PR TITLE
Fix NoMethodError bug due to nil worker

### DIFF
--- a/lib/parallel.rb
+++ b/lib/parallel.rb
@@ -392,7 +392,7 @@ module Parallel
               rescue
                 exception = $!
                 if Parallel::Kill === exception
-                  (workers - [worker]).each do |w|
+                  (workers - [worker]).compact.each do |w|
                     w.thread.kill unless w.thread.nil?
                     UserInterruptHandler.kill(w.pid)
                   end
@@ -436,7 +436,7 @@ module Parallel
         self.worker_number = options[:worker_number]
 
         begin
-          options.delete(:started_workers).each(&:close_pipes)
+          options.delete(:started_workers).compact.each(&:close_pipes)
 
           parent_write.close
           parent_read.close


### PR DESCRIPTION
## Summary

We replace Parallel::Worker object in workers
by `Array#[]=` in the isolation mode.
The assignment generates `nil` element in workers
when `worker.size` is below the specified index.

https://github.com/grosser/parallel/blob/88c75b70480c5735463c47b4048ec36711a90902/lib/parallel.rb#L411-L421

This is possible since the order of the execution and index is not fixed.

https://github.com/grosser/parallel/blob/88c75b70480c5735463c47b4048ec36711a90902/lib/parallel.rb#L203-L208

In the previous code, this `nil` element
resulted in NoMethodError when `worker.each` was called.
This patch fixes the bug by calling `Array#compact` beforehand.

## How to reproduce

Since this bug occurs randomly, we have to increase `in_processes` and keep running the code until we hit a jackpot.


### code

```ruby
require 'parallel'

targets = Array.new(10000)
Parallel.map(targets, in_processes: 1000, isolation: true) do
  print '.'
end
```

### result

```
$ ruby -v
ruby 2.3.1p112 (2016-04-26 revision 54768) [x86_64-darwin16]
$ bundle exec ruby my_test.rb
............................................................................................/Users/user-name/git/public/parallel/lib/parallel.rb:439:in `each': undefined method `close_pipes' for nil:NilClass (NoMethodError)
	from /Users/user-name/git/public/parallel/lib/parallel.rb:439:in `block in worker'
	from /Users/user-name/git/public/parallel/lib/parallel.rb:435:in `fork'
	from /Users/user-name/git/public/parallel/lib/parallel.rb:435:in `worker'
	from /Users/user-name/git/public/parallel/lib/parallel.rb:419:in `block in replace_worker'
	from /Users/user-name/git/public/parallel/lib/parallel.rb:412:in `synchronize'
	from /Users/user-name/git/public/parallel/lib/parallel.rb:412:in `replace_worker'
	from /Users/user-name/git/public/parallel/lib/parallel.rb:382:in `block (3 levels) in work_in_processes'
	from /Users/user-name/git/public/parallel/lib/parallel.rb:376:in `loop'
	from /Users/user-name/git/public/parallel/lib/parallel.rb:376:in `block (2 levels) in work_in_processes'
	from /Users/user-name/git/public/parallel/lib/parallel.rb:206:in `block (2 levels) in in_threads'
```

## Other Information

We can safely use `Array#compact` with Ruby 2.2.
https://ruby-doc.org/core-2.2.0/Array.html#method-i-compact
