### PR TITLE
Fix travis build for bundler

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,14 @@ before_install:
   - travis_retry gem update --system
   - travis_retry gem install bundler --no-document
 rvm:
-  - 2.2
   - 2.3
   - 2.4
   - 2.5
   - 2.6.2
+matrix:
+  include:
+    - rvm: 2.2
+      before_install:
+        - travis_retry gem update --system 2.7.8
+        - travis_retry gem uninstall -v '>= 2' -i $(rvm gemdir)@global -ax bundler || true
+        - travis_retry gem install bundler -v '< 2'

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,12 @@ sudo: false
 dist: precise
 branches:
   only: master
+before_install:
+  - travis_retry gem update --system
+  - travis_retry gem install bundler --no-document
 rvm:
   - 2.2
   - 2.3
   - 2.4
   - 2.5
-  - 2.6.1
+  - 2.6.2


### PR DESCRIPTION
### Summary

This setting change fixes the failing travis build.

### Details

* Update ruby 2.6.1 to ruby 2.6.2
  * This includes bundler fix
  * https://www.ruby-lang.org/en/news/2019/03/13/ruby-2-6-2-released/
  * https://bugs.ruby-lang.org/issues/15469#note-4
* Update gem and bundler at `before_install`
  * https://docs.travis-ci.com/user/languages/ruby/#bundler-20