### PR TITLE
Ensure kill child threads

### DIFF
--- a/lib/parallel.rb
+++ b/lib/parallel.rb
@@ -205,7 +205,7 @@ module Parallel
       threads = Array.new(count) do |i|
         Thread.new { yield(i) }
       end
-      threads.map!(&:value)
+      threads.map(&:value)
     ensure
       threads.each(&:kill)
     end

--- a/lib/parallel.rb
+++ b/lib/parallel.rb
@@ -465,7 +465,11 @@ module Parallel
         rescue
           ExceptionWrapper.new($!)
         end
-        Marshal.dump(result, write)
+        begin
+          Marshal.dump(result, write)
+        rescue Errno::EPIPE
+          return # parent thread already dead
+        end
       end
     end
 

--- a/lib/parallel.rb
+++ b/lib/parallel.rb
@@ -202,9 +202,12 @@ module Parallel
   class << self
     def in_threads(options={:count => 2})
       count, _ = extract_count_from_options(options)
-      Array.new(count) do |i|
+      threads = Array.new(count) do |i|
         Thread.new { yield(i) }
-      end.map!(&:value)
+      end
+      threads.map!(&:value)
+    ensure
+      threads.each(&:kill)
     end
 
     def in_processes(options = {}, &block)


### PR DESCRIPTION
Currently, when parent thread is killed, the child threads/processes will remain.

I think they can be handled by simply ensuring to `kill` each thread in the `in_threads` method, since `kill` against dead thread is just an No-Op.

Any opinion?