### PR TITLE
freeze Stop object

### DIFF
--- a/lib/parallel.rb
+++ b/lib/parallel.rb
@@ -22,7 +22,7 @@ module Parallel
     end
   end
 
-  Stop = Object.new
+  Stop = Object.new.freeze
 
   class ExceptionWrapper
     attr_reader :exception


### PR DESCRIPTION
Since it is a constant, always better to freeze.