### PR TITLE
Fix travis failure by removing bundled version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -65,6 +65,3 @@ DEPENDENCIES
   rspec-rerun
   ruby-progressbar
   sqlite3
-
-BUNDLED WITH
-   2.0.1


### PR DESCRIPTION
@grosser 

It seems like travis got failing again by an accident.

https://github.com/grosser/parallel/commit/0ac48d22db394726ff69fcfb9ee434f374447e70#diff-e79a60dc6b85309ae70a6ea8261eaf95

This patch will fix it by removing the version information from `Gemfile.lock`
like #247

