### PR TITLE
control timing of async exception

### DIFF
--- a/lib/parallel.rb
+++ b/lib/parallel.rb
@@ -208,7 +208,7 @@ module Parallel
           count.times do |i|
             threads << Thread.new { yield(i) }
           end
-          Thread.handle_interrupt(Exception => :always) do
+          Thread.handle_interrupt(Exception => :immediate) do
             threads.map(&:value)
           end
         ensure

--- a/lib/parallel.rb
+++ b/lib/parallel.rb
@@ -201,13 +201,20 @@ module Parallel
 
   class << self
     def in_threads(options={:count => 2})
-      count, _ = extract_count_from_options(options)
-      threads = Array.new(count) do |i|
-        Thread.new { yield(i) }
+      Thread.handle_interrupt(Exception => :never) do
+        begin
+          threads = []
+          count, _ = extract_count_from_options(options)
+          count.times do |i|
+            threads << Thread.new { yield(i) }
+          end
+          Thread.handle_interrupt(Exception => :always) do
+            threads.map(&:value)
+          end
+        ensure
+          threads.each(&:kill)
+        end
       end
-      threads.map(&:value)
-    ensure
-      threads.each(&:kill)
     end
 
     def in_processes(options = {}, &block)


### PR DESCRIPTION
In ruby, async exception can be raised at arbitrary timing.
To make sure to kill each child threads, use Thread.handle_interrupt.

Refer:
https://docs.ruby-lang.org/en/2.6.0/Thread.html#method-c-handle_interrupt