### PR TITLE
Migrate travis badge from PNG to SVG

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,7 +1,7 @@
 Parallel
 ==============
 [![Gem Version](https://badge.fury.io/rb/parallel.svg)](https://rubygems.org/gems/parallel)
-[![Build Status](https://travis-ci.org/grosser/parallel.png)](https://travis-ci.org/grosser/parallel)
+[![Build Status](https://travis-ci.org/grosser/parallel.svg?branch=master)](https://travis-ci.org/grosser/parallel)
 
 
 Run any code in parallel Processes(> use all CPUs) or Threads(> speedup blocking operations).<br/>


### PR DESCRIPTION
Since travis now supports SVG as its default,
this patch migrate the badge on Readme.md to SVG.

https://blog.travis-ci.com/2014-03-20-build-status-badges-support-svg/
https://travis-ci.org/grosser/parallel

This beautify the travis badge on Readme.md and unify all the badge styles to SVG.