### PR TITLE
Added travis testing of experimental Ruby 2.6+ JIT

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,9 @@ language: ruby
 cache: bundler
 dist: precise
 branches:
-  only: master
+  only: 
+    - master
+    - ruby_jit
 rvm:
   - 2.2
   - 2.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,4 +9,21 @@ rvm:
   - 2.4
   - 2.5
   - 2.6
+
+env:
+  - RUBYOPT="--jit"
+  - ""
+
+matrix:
+  exclude:
+    - rvm: 2.2
+      env: RUBYOPT="--jit"
+    - rvm: 2.3
+      env: RUBYOPT="--jit"
+    - rvm: 2.4
+      env: RUBYOPT="--jit"
+    - rvm: 2.5
+      env: RUBYOPT="--jit"
+
+
 before_install: ruby -e "File.write('Gemfile.lock', File.read('Gemfile.lock').split('BUNDLED WITH').first)"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,7 @@
 language: ruby
 dist: precise
 branches:
-  only: 
-    - master
-    - ruby_jit
+  only: master
 rvm:
   - 2.2
   - 2.3
@@ -27,6 +25,5 @@ matrix:
       env: RUBYOPT="--jit"
   allow_failures:
     - env: RUBYOPT="--jit"
-
 
 before_install: ruby -e "File.write('Gemfile.lock', File.read('Gemfile.lock').split('BUNDLED WITH').first)"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: ruby
-dist: precise
+dist: xenial
 branches:
   only: master
 rvm:

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,8 @@ matrix:
       env: RUBYOPT="--jit"
     - rvm: 2.5
       env: RUBYOPT="--jit"
+  allow_failures:
+    - env: RUBYOPT="--jit"
 
 
 before_install: ruby -e "File.write('Gemfile.lock', File.read('Gemfile.lock').split('BUNDLED WITH').first)"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: ruby
-dist: xenial
+dist: precise
 branches:
   only: master
 rvm:
@@ -9,19 +9,9 @@ rvm:
   - 2.5
   - 2.6
 
-env:
-  - RUBYOPT="--jit"
-  - ""
-
 matrix:
-  exclude:
-    - rvm: 2.2
-      env: RUBYOPT="--jit"
-    - rvm: 2.3
-      env: RUBYOPT="--jit"
-    - rvm: 2.4
-      env: RUBYOPT="--jit"
-    - rvm: 2.5
+  include:
+    - rvm: 2.6
       env: RUBYOPT="--jit"
   allow_failures:
     - env: RUBYOPT="--jit"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: ruby
-cache: bundler
 dist: precise
 branches:
   only: 


### PR DESCRIPTION
I added `RUBYOPT="--jit"` to the build matrix, but explicitly excluded it from everything but 2.6.

Here's what a build looks like:
<img width="759" alt="Travis" src="https://user-images.githubusercontent.com/382216/55828461-1b599b00-5ad2-11e9-99c8-e195581d6440.png">

The JIT job doesn't pass and takes a long time, but it's still experimental.  I set it as an allowed failure.

I've seen 200% speed improvements in single threaded code with `--jit` but it Segfaults using Parallel.  If I can track down the reasons I'll add tests.  It's exciting though, and I think it'd would be good to have on your radar for Parallel.