### PR TITLE
Make sure to also rescue non-standard error

### DIFF
--- a/lib/parallel.rb
+++ b/lib/parallel.rb
@@ -469,7 +469,7 @@ module Parallel
         item, index = job_factory.unpack(data)
         result = begin
           call_with_index(item, index, options, &block)
-        rescue SystemExit
+        rescue SystemExit, SignalException
           raise $!
         rescue Exception
           ExceptionWrapper.new($!)

--- a/lib/parallel.rb
+++ b/lib/parallel.rb
@@ -469,7 +469,9 @@ module Parallel
         item, index = job_factory.unpack(data)
         result = begin
           call_with_index(item, index, options, &block)
-        rescue
+        rescue SystemExit
+          raise $!
+        rescue Exception
           ExceptionWrapper.new($!)
         end
         begin

--- a/spec/cases/exception_raised_in_process.rb
+++ b/spec/cases/exception_raised_in_process.rb
@@ -1,0 +1,11 @@
+require './spec/cases/helper'
+
+begin
+  Parallel.each([1]){ raise Exception }
+rescue Parallel::DeadWorker
+  puts "No, DEAD worker found"
+rescue Exception
+  puts "Yep, rescued the exception"
+else
+  puts "WHOOOPS"
+end

--- a/spec/parallel_spec.rb
+++ b/spec/parallel_spec.rb
@@ -385,6 +385,10 @@ describe Parallel do
       `ruby spec/cases/exit_in_process.rb 2>&1`.should include "Yep, DEAD"
     end
 
+    it "should rescue the Exception raised in child process" do
+      `ruby spec/cases/exception_raised_in_process.rb 2>&1`.should include "Yep, rescued the exception"
+    end
+
     it 'raises EOF (not DeadWorker) when a worker raises EOF in process' do
       `ruby spec/cases/eof_in_process.rb 2>&1`.should include 'Yep, EOF'
     end


### PR DESCRIPTION
A potential way to solve #268

I tried to raise the SystemExit again as we have this test case:

    raises DeadWorker when using exit so people learn to not kill workers and do not crash main process

If I just rescue all the exceptions, this test will fail since no DeadWorker will be raised when the worker exits.

I'm also thinking about allowing users to specify the non-standard errors that they wish to rescue. By doing this, we may not need to handle all different edge cases and just let the users choose what to rescue.

```ruby
Parallel.each([1,2,3], extra_exceptions_to_handle: [Exception]) do |index|
end
```