### PR TITLE
Add project metadata to the gemspec

### DIFF
--- a/parallel.gemspec
+++ b/parallel.gemspec
@@ -7,6 +7,12 @@ Gem::Specification.new name, Parallel::VERSION do |s|
   s.authors = ["Michael Grosser"]
   s.email = "michael@grosser.it"
   s.homepage = "https://github.com/grosser/#{name}"
+  s.metadata = {
+    "bug_tracker_uri"   => "https://github.com/grosser/#{name}/issues",
+    "documentation_uri" => "https://www.rubydoc.info/gems/#{name}/#{s.version}",
+    "source_code_uri"   => "https://github.com/grosser/#{name}/tree/v#{s.version}",
+    "wiki_uri"          => "https://github.com/grosser/#{name}/wiki",
+  }
   s.files = `git ls-files lib MIT-LICENSE.txt`.split("\n")
   s.license = "MIT"
   s.required_ruby_version = '>= 2.2'

--- a/parallel.gemspec
+++ b/parallel.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new name, Parallel::VERSION do |s|
   s.homepage = "https://github.com/grosser/#{name}"
   s.metadata = {
     "bug_tracker_uri"   => "https://github.com/grosser/#{name}/issues",
-    "documentation_uri" => "https://www.rubydoc.info/gems/#{name}/#{s.version}",
+    "documentation_uri" => "https://github.com/grosser/#{name}/blob/v#{s.version}/Readme.md",
     "source_code_uri"   => "https://github.com/grosser/#{name}/tree/v#{s.version}",
     "wiki_uri"          => "https://github.com/grosser/#{name}/wiki",
   }


### PR DESCRIPTION
Add `bug_tracker_uri`, `wiki_uri`, `documentation_uri`, and `source_code_uri` to the gemspec metadata.

These [project metadata](https://guides.rubygems.org/specification-reference/#metadata) will facilitate easy access to project information. The URI will be available on the [Rubygems project page](https://rubygems.org/gems/parallel), via the rubygems API, and the `gem` and `bundle` command-line tools with the next release.