### PR TITLE
Allow timeout usage inside of threads

### DIFF
--- a/lib/parallel.rb
+++ b/lib/parallel.rb
@@ -201,14 +201,15 @@ module Parallel
 
   class << self
     def in_threads(options={:count => 2})
+      threads = []
+      count, _ = extract_count_from_options(options)
+
       Thread.handle_interrupt(Exception => :never) do
         begin
-          threads = []
-          count, _ = extract_count_from_options(options)
-          count.times do |i|
-            threads << Thread.new { yield(i) }
-          end
           Thread.handle_interrupt(Exception => :immediate) do
+            count.times do |i|
+              threads << Thread.new { yield(i) }
+            end
             threads.map(&:value)
           end
         ensure

--- a/spec/cases/timeout_in_threads.rb
+++ b/spec/cases/timeout_in_threads.rb
@@ -1,0 +1,12 @@
+require './spec/cases/helper'
+require 'timeout'
+
+Parallel.each([1], in_threads: 1) do |i|
+  begin
+    Timeout.timeout(0.1) { sleep 0.2 }
+  rescue Timeout::Error
+    puts "OK"
+  else
+    puts "BROKEN"
+  end
+end

--- a/spec/parallel_spec.rb
+++ b/spec/parallel_spec.rb
@@ -467,6 +467,11 @@ describe Parallel do
       out = `ruby spec/cases/map_worker_number_isolation.rb`
       out.should == "0,1\nOK"
     end
+
+    it 'can use Timeout' do
+      out = `ruby spec/cases/timeout_in_threads.rb`
+      out.should == "OK\n"
+    end
   end
 
   describe ".map_with_index" do


### PR DESCRIPTION
fixes https://github.com/grosser/parallel/issues/276 /cc @owst 

introduced in https://github.com/grosser/parallel/pull/251 when all exceptions were ignored during execution even though we only wanted to ignore our own `ensure` /cc @Yuki-Inoue 

