### PR TITLE
bring back ruby 2.4 since that broke rubocop builds because of some d…

### DIFF
--- a/parallel.gemspec
+++ b/parallel.gemspec
@@ -15,5 +15,5 @@ Gem::Specification.new name, Parallel::VERSION do |s|
   }
   s.files = `git ls-files lib MIT-LICENSE.txt`.split("\n")
   s.license = "MIT"
-  s.required_ruby_version = '>= 2.5'
+  s.required_ruby_version = '>= 2.4'
 end


### PR DESCRIPTION
…ependency foobar

see https://github.com/grosser/parallel/commit/d191db712917a13c0beee3bc6b6c0a45b8181521#commitcomment-44432975

```
Installing parallel 1.20.0
Gem::RuntimeRequirementNotMetError: parallel requires Ruby version >= 2.5. The
current ruby version is 2.4.10.364.
An error occurred while installing parallel (1.20.0), and Bundler
cannot continue.
Make sure that `gem install parallel -v '1.20.0' --source
'https://rubygems.org/'` succeeds before bundling.

In Gemfile:
  rubocop-performance was resolved to 1.9.0, which depends on
    rubocop was resolved to 1.3.1, which depends on
      parallel

```