### PR TITLE
Test against ruby 3.0

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -12,7 +12,7 @@ jobs:
         image: mysql
     strategy:
       matrix:
-        ruby: [ '2.5', '2.6', '2.7' ]
+        ruby: [ '2.5', '2.6', '2.7', '3.0' ]
     name: ${{ matrix.ruby }} rake ${{ matrix.task }}
     steps:
     - uses: actions/checkout@v2

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -22,7 +22,7 @@ GEM
     diff-lcs (1.3)
     i18n (1.8.3)
       concurrent-ruby (~> 1.0)
-    minitest (5.14.1)
+    minitest (5.14.4)
     mysql2 (0.5.3)
     rake (13.0.1)
     rspec (3.6.0)
@@ -67,4 +67,4 @@ DEPENDENCIES
   sqlite3
 
 BUNDLED WITH
-   2.1.4
+   2.2.3


### PR DESCRIPTION
This PR changes tiny version up for minitest the reason is described at https://github.com/grosser/parallel/commit/e06ec5fca4fa2b325da0fe275cc9c578c0ccbef2

---

`bundle install` on ruby 3.0 makes following error

```
minitest-5.14.1 requires ruby version ~> 2.2, which is incompatible with the current version, ruby 3.0.0p0
```

And minitest 5.14.4 still supports ruby 2.2

https://rubygems.org/gems/minitest/versions/5.14.4