### PR TITLE
Fix or Update a contributors link of @masatomo

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -181,7 +181,7 @@ Authors
 ### [Contributors](https://github.com/grosser/parallel/graphs/contributors)
  - [Przemyslaw Wroblewski](https://github.com/lowang)
  - [TJ Holowaychuk](http://vision-media.ca/)
- - [Masatomo Nakano](https://twitter.com/masatomo2)
+ - [Masatomo Nakano](https://github.com/masatomo)
  - [Fred Wu](http://fredwu.me)
  - [mikezter](https://github.com/mikezter)
  - [Jeremy Durham](http://www.jeremydurham.com)


### PR DESCRIPTION
`git log --author='masatomo'`
`git log --author='Masatomo Nakano'`

Both hits only bccbec4762cf7b3b120eea5ba593a7fae3b56c7f

I couldn't find any source of `masatomon@reallyenglish.com`,
But @masatomo has https://github.com/masatomo/parallel_tests
I guess this is a his work :smile:.