### PR TITLE
Add support for darwin20

### DIFF
--- a/lib/parallel/processor_count.rb
+++ b/lib/parallel/processor_count.rb
@@ -12,7 +12,7 @@ module Parallel
     def physical_processor_count
       @physical_processor_count ||= begin
         ppc = case RbConfig::CONFIG["target_os"]
-        when /darwin1/
+        when /darwin[12]/,
           IO.popen("/usr/sbin/sysctl -n hw.physicalcpu").read.to_i
         when /linux/
           cores = {}  # unique physical ID / core ID combinations


### PR DESCRIPTION
Properly determine physical cpu on darwin20.

![image](https://user-images.githubusercontent.com/228088/130691874-862bd68d-d986-46f4-8dc3-d9d3b4e5e099.png)

![image](https://user-images.githubusercontent.com/228088/130691947-02b4dac3-ea86-4df4-ab04-c79b0ed43a18.png)
