### PR TITLE
Avoid thousands of lsof warnings in chroot

### DIFF
--- a/spec/cases/count_open_pipes.rb
+++ b/spec/cases/count_open_pipes.rb
@@ -1,5 +1,5 @@
 require './spec/cases/helper'
-count = ->(*) { `lsof | grep pipe | wc -l`.to_i }
+count = ->(*) { `lsof -l | grep pipe | wc -l`.to_i }
 start = count.()
 results = Parallel.map(Array.new(20), :in_processes => 20, &count)
 puts results.max - start


### PR DESCRIPTION
Just executing lsof in pbuilder/cowbuilder chroot environment causes flood of warnings. Just -l option avoids this noise.
In chroot environment, /etc/passwd is a limited one but /proc has lot of processes that are related to users in the parent environment.

-l option means "inhibits  the  conversion of user ID numbers to login names."