### PR TITLE
CI: Use matrix.task value in Rake Step

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -24,4 +24,4 @@ jobs:
       with:
         ruby-version: ${{ matrix.ruby }}
         bundler-cache: true # runs 'bundle install' and caches installed gems automatically
-    - run: bundle exec rake
+    - run: bundle exec rake ${{ matrix.task }}

--- a/Rakefile
+++ b/Rakefile
@@ -5,7 +5,7 @@ require 'bump/tasks'
 require "rspec/core/rake_task"
 require 'rspec-rerun/tasks'
 
-task default: ["spec", "rubocop"]
+task default: :spec
 
 desc "Run tests"
 task spec: "rspec-rerun:spec"


### PR DESCRIPTION
This wants to go with another change: unhook the RuboCop linting from the default Rake task.