### PR TITLE
Fix compilation on windows

### DIFF
--- a/lib/parallel/processor_count.rb
+++ b/lib/parallel/processor_count.rb
@@ -1,11 +1,10 @@
 # frozen_string_literal: true
-require 'etc'
-
 module Parallel
   # TODO: inline this method into parallel.rb and kill physical_processor_count in next major release
   module ProcessorCount
     # Number of processors seen by the OS, used for process scheduling
     def processor_count
+      require 'etc'
       @processor_count ||= Integer(ENV['PARALLEL_PROCESSOR_COUNT'] || Etc.nprocessors)
     end
 


### PR DESCRIPTION
I have an application using the parallel gem. It works fine but when I compile it into exe I get an error that I'm missing the etc gem.

However I'm unable to install that gem on windows due to https://github.com/ruby/etc/issues/22. However this gem doesn't seem to be strictly necessary for parallel and on windows the branch where it's used won't be reached anyway. Can we only call the require when actually using the gem?

EDIT: I tested this change by modifying the parallel gem locally and it indeed fixes the problem.