### PR TITLE
Drop win32ole

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -19,7 +19,7 @@ jobs:
           task: rubocop
     name: ${{ matrix.ruby }} rake ${{ matrix.task }}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby }}

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -12,7 +12,7 @@ jobs:
         image: mysql
     strategy:
       matrix:
-        ruby: [ '2.7', '3.0', '3.1', '3.2' ]
+        ruby: [ '2.7', '3.0', '3.1', '3.2', '3.3' ]
         task: [ 'spec' ]
         include:
         - ruby: 2.7 # keep in sync with lowest version

--- a/Gemfile
+++ b/Gemfile
@@ -14,4 +14,4 @@ gem 'rubocop-rake'
 gem 'rubocop-rspec'
 
 gem 'mysql2', group: :mysql
-gem 'sqlite3'
+gem 'sqlite3', '~> 1.4'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -26,6 +26,7 @@ GEM
     json (2.7.1)
     json (2.7.1-java)
     language_server-protocol (3.17.0.3)
+    mini_portile2 (2.8.7)
     minitest (5.15.0)
     mysql2 (0.5.6)
     parser (3.3.0.5)
@@ -72,7 +73,8 @@ GEM
     rubocop-rspec (2.9.0)
       rubocop (~> 1.19)
     ruby-progressbar (1.13.0)
-    sqlite3 (1.4.2)
+    sqlite3 (1.7.3)
+      mini_portile2 (~> 2.8.0)
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.5.0)
@@ -95,7 +97,7 @@ DEPENDENCIES
   rubocop-rake
   rubocop-rspec
   ruby-progressbar
-  sqlite3
+  sqlite3 (~> 1.4)
 
 BUNDLED WITH
    2.3.12

--- a/lib/parallel.rb
+++ b/lib/parallel.rb
@@ -328,11 +328,7 @@ module Parallel
             end
             cores.count
           when /mswin|mingw/
-            require 'win32ole'
-            result_set = WIN32OLE.connect("winmgmts://").ExecQuery(
-              "select NumberOfCores from Win32_Processor"
-            )
-            result_set.to_enum.collect(&:NumberOfCores).reduce(:+)
+            physical_processor_count_windows
           else
             processor_count
           end
@@ -357,6 +353,33 @@ module Parallel
     end
 
     private
+
+    def physical_processor_count_windows
+      # Get-CimInstance introduced in PowerShell 3 or earlier: https://learn.microsoft.com/en-us/previous-versions/powershell/module/cimcmdlets/get-ciminstance?view=powershell-3.0
+      result = run(
+        'powershell -command "Get-CimInstance -ClassName Win32_Processor ' \
+        '| Select-Object -Property NumberOfCores"'
+      )
+      if !result || $?.exitstatus != 0
+        # fallback to deprecated wmic for older systems
+        result = run("wmic cpu get NumberOfCores")
+      end
+      if !result || $?.exitstatus != 0
+        # Bail out if both commands returned something unexpected
+        warn "guessing pyhsical processor count"
+        processor_count
+      else
+        # powershell: "\nNumberOfCores\n-------------\n            4\n\n\n"
+        # wmic:       "NumberOfCores  \n\n4              \n\n\n\n"
+        result.scan(/\d+/).map(&:to_i).reduce(:+)
+      end
+    end
+
+    def run(command)
+      IO.popen(command, &:read)
+    rescue Errno::ENOENT
+      # Ignore
+    end
 
     def add_progress_bar!(job_factory, options)
       if (progress_options = options[:progress])

--- a/spec/parallel_spec.rb
+++ b/spec/parallel_spec.rb
@@ -736,7 +736,7 @@ describe Parallel do
     def normalize(result)
       result = result.sub(/\{(.*)\}/, "\\1").split(", ")
       result.reject! { |x| x =~ /^(Hash|Array|String)=>(1|-1|-2)$/ }
-      result.reject! { |x| x =~ /^(Mutex)=>(1)$/ } if RUBY_VERSION < "2.0"
+      result.reject! { |x| x =~ /^(Thread::Mutex)=>(1)$/ } if RUBY_VERSION >= "3.3"
       result
     end
 


### PR DESCRIPTION
Closes #345

I refined my initial approach for this. The PR I linked in the issue for `ruby-concurrency` got merged and released.

I tried adding CI on windows for this but didn't quite manage, the mysql gem fails to compile. I also tried adding Ruby 3.3 to the matrix but there's one memory leak test that consistently fails:
> Parallel GC does not leak memory in threads
![image](https://github.com/grosser/parallel/assets/14981592/84d73029-5a6d-4355-bc8b-ecdd22497639)

So I just bump `actions/checkout` to prevent a deprecation warning about old node versions.
