### PR TITLE
Improve speed for `Get-CimInstance`

### DIFF
--- a/lib/parallel.rb
+++ b/lib/parallel.rb
@@ -357,7 +357,7 @@ module Parallel
     def physical_processor_count_windows
       # Get-CimInstance introduced in PowerShell 3 or earlier: https://learn.microsoft.com/en-us/previous-versions/powershell/module/cimcmdlets/get-ciminstance?view=powershell-3.0
       result = run(
-        'powershell -command "Get-CimInstance -ClassName Win32_Processor ' \
+        'powershell -command "Get-CimInstance -ClassName Win32_Processor -Property NumberOfCores ' \
         '| Select-Object -Property NumberOfCores"'
       )
       if !result || $?.exitstatus != 0


### PR DESCRIPTION
Small followup for #346

In terms of the previous code, this currently does `select * from Win32_Processor` which is slower. I missed this in the other PR, this improves the speed when detection runs on windows.

The pipe is still needed since that command returns all properties anyways, they are just empty/not computed.