### PR TITLE
Use cgroups aware processor count by default

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -196,6 +196,7 @@ Tips
  - [Isolation] Do not reuse previous worker processes: `isolation: true`
  - [Stop all processes with an alternate interrupt signal] `'INT'` (from `ctrl+c`) is caught by default. Catch `'TERM'` (from `kill`) with `interrupt_signal: 'TERM'`
  - [Process count via ENV] `PARALLEL_PROCESSOR_COUNT=16` will use `16` instead of the number of processors detected. This is used to reconfigure a tool using `parallel` without inserting custom logic.
+ - [Process count] `parallel` uses a number of processors seen by the OS for process count by default. If you want to use a value considering CPU quota, please add `concurrent-ruby` to your `Gemfile`.
 
 TODO
 ====

--- a/spec/parallel_spec.rb
+++ b/spec/parallel_spec.rb
@@ -49,11 +49,6 @@ describe Parallel do
         (1..999).should include(Parallel.processor_count)
       end
     end
-
-    it 'uses Etc.nprocessors in Ruby 2.2+' do
-      defined?(Etc).should == "constant"
-      Etc.respond_to?(:nprocessors).should == true
-    end
   end
 
   describe ".physical_processor_count" do


### PR DESCRIPTION
In containerized environments, a number of CPU cores isn't the same as the available CPUs. In this case, we need to consider cgroups.

`concurrent-ruby` now has the method to get that since v1.3.1. I think it's better to use this for setting more container environment friendly default value. Ref: https://github.com/ruby-concurrency/concurrent-ruby/pull/1038

I keep `Parallel.processor_count` as is to keep supporting setting processor count via env(`PARALLEL_PROCESSOR_COUNT`).