### PR TITLE
Ensure not to use old `concurrent-ruby`

### DIFF
--- a/lib/parallel.rb
+++ b/lib/parallel.rb
@@ -697,9 +697,10 @@ module Parallel
     end
 
     def available_processor_count
+      gem 'concurrent-ruby', '>= 1.3.4'
       require 'concurrent-ruby'
       Concurrent.available_processor_count.floor
-    rescue LoadError, NoMethodError
+    rescue LoadError
       require 'etc'
       Etc.nprocessors
     end


### PR DESCRIPTION
It seems that some users encounter with a negative values issue of `Concurrent.available_processor_count`.
https://github.com/grosser/parallel/issues/349#issuecomment-2290381980

To avoid the issue, this PR ensure not to use old `concurrent-ruby`. This PR also removes considering of `NoMethodError` because we can assume to use `available_processor_count` always.