### PR TITLE
Kill replaced worker processes when interrupted

### DIFF
--- a/lib/parallel.rb
+++ b/lib/parallel.rb
@@ -168,45 +168,20 @@ module Parallel
     INTERRUPT_SIGNAL = :SIGINT
 
     class << self
-      # kill all these pids or threads if user presses Ctrl+c
+      # kill all these workers if user presses Ctrl+c
       def kill_on_ctrl_c(workers, options)
         @to_be_killed ||= []
-        old_interrupt = nil
+        old_handler = nil
         signal = options.fetch(:interrupt_signal, INTERRUPT_SIGNAL)
 
-        if @to_be_killed.empty?
-          # Wrap the existing interrupt handler to kill the workers first. Workers may have been replaced,
-          # so get the latest pids.
-          # 1. The worker arrays in @to_be_killed are protected by options[:mutex].
-          # 2. Mutexes cannot be obtained in a trap context.
-          # 3. To preserve semantics, the workers must be killed before the old handler runs.
-          # 4. To preserve semantics, the old handler must run in a trap context on the main thread.
-          kill_thread = nil
-          old_interrupt = Signal.trap(signal) do
-            next if kill_thread
-            warn 'Parallel execution interrupted, exiting ...'
-            kill_thread = Thread.new do
-              pids = options[:mutex].synchronize do
-                @to_be_killed.flatten(1).map(&:pid)
-                # FUTURE: stop JobFactory from spawning new workers
-              end
-              pids.each { |pid| kill(pid) }
-              if old_interrupt == "DEFAULT"
-                Signal.trap(signal) { raise Interrupt }
-              else
-                Signal.trap(signal, old_interrupt)
-              end
-              Process.kill(signal, Process.pid) # run the old interrupt handler
-            end
-          end || "DEFAULT"
-        end
+        old_handler = wrap_interrupt(signal, options[:mutex]) || "DEFAULT" if @to_be_killed.empty?
 
         @to_be_killed << workers
 
         yield
       ensure
         @to_be_killed.pop # do not kill pids that could be used for new processes
-        Signal.trap(signal, old_interrupt) if @to_be_killed.empty? # restore the old handler on our way out
+        Signal.trap(signal, old_handler) if old_handler # restore the old handler on our way out
       end
 
       def kill(thing)
@@ -214,6 +189,35 @@ module Parallel
       rescue Errno::ESRCH
         # some linux systems already automatically killed the children at this point
         # so we just ignore them not being there
+      end
+
+      private
+
+      # Wrap the existing interrupt handler to kill the workers first. Workers may have been replaced,
+      # so get the latest pids.
+      # 1. The worker arrays in @to_be_killed are protected by the mutex.
+      # 2. Mutexes cannot be obtained in a trap context.
+      # 3. To preserve semantics, the workers must be killed before the old handler runs.
+      # 4. To preserve semantics, the old handler must run in a trap context on the main thread.
+      def wrap_interrupt(signal, mutex)
+        kill_thread = nil
+        old_handler = Signal.trap(signal) do
+          next if kill_thread
+          warn 'Parallel execution interrupted, exiting ...'
+          kill_thread = Thread.new do
+            pids = mutex.synchronize do
+              @to_be_killed.flatten(1).map(&:pid)
+              # FUTURE: stop JobFactory from spawning new workers
+            end
+            pids.each { |pid| kill(pid) }
+            if old_handler == "DEFAULT"
+              Signal.trap(signal) { raise Interrupt }
+            else
+              Signal.trap(signal, old_handler)
+            end
+            Process.kill(signal, Process.pid) # run the old interrupt handler
+          end
+        end
       end
     end
   end

--- a/lib/parallel.rb
+++ b/lib/parallel.rb
@@ -174,7 +174,7 @@ module Parallel
         old_handler = nil
         signal = options.fetch(:interrupt_signal, INTERRUPT_SIGNAL)
 
-        old_handler = wrap_interrupt(signal, options[:mutex]) || "DEFAULT" if @to_be_killed.empty?
+        old_handler = wrap_interrupt(signal, options[:mutex]) if @to_be_killed.empty?
 
         @to_be_killed << workers
 
@@ -217,7 +217,7 @@ module Parallel
             end
             Process.kill(signal, Process.pid) # run the old interrupt handler
           end
-        end
+        end || "DEFAULT"
       end
     end
   end

--- a/lib/parallel.rb
+++ b/lib/parallel.rb
@@ -169,24 +169,44 @@ module Parallel
 
     class << self
       # kill all these pids or threads if user presses Ctrl+c
-      def kill_on_ctrl_c(pids, options)
+      def kill_on_ctrl_c(workers, options)
         @to_be_killed ||= []
         old_interrupt = nil
         signal = options.fetch(:interrupt_signal, INTERRUPT_SIGNAL)
 
         if @to_be_killed.empty?
-          old_interrupt = trap_interrupt(signal) do
+          # Wrap the existing interrupt handler to kill the workers first. Workers may have been replaced,
+          # so get the latest pids.
+          # 1. The worker arrays in @to_be_killed are protected by options[:mutex].
+          # 2. Mutexes cannot be obtained in a trap context.
+          # 3. To preserve semantics, the workers must be killed before the old handler runs.
+          # 4. To preserve semantics, the old handler must run in a trap context on the main thread.
+          kill_thread = nil
+          old_interrupt = Signal.trap(signal) do
+            next if kill_thread
             warn 'Parallel execution interrupted, exiting ...'
-            @to_be_killed.flatten.each { |pid| kill(pid) }
-          end
+            kill_thread = Thread.new do
+              pids = options[:mutex].synchronize do
+                @to_be_killed.flatten(1).map(&:pid)
+                # FUTURE: stop JobFactory from spawning new workers
+              end
+              pids.each { |pid| kill(pid) }
+              if old_interrupt == "DEFAULT"
+                Signal.trap(signal) { raise Interrupt }
+              else
+                Signal.trap(signal, old_interrupt)
+              end
+              Process.kill(signal, Process.pid) # run the old interrupt handler
+            end
+          end || "DEFAULT"
         end
 
-        @to_be_killed << pids
+        @to_be_killed << workers
 
         yield
       ensure
         @to_be_killed.pop # do not kill pids that could be used for new processes
-        restore_interrupt(old_interrupt, signal) if @to_be_killed.empty?
+        Signal.trap(signal, old_interrupt) if @to_be_killed.empty? # restore the old handler on our way out
       end
 
       def kill(thing)
@@ -194,27 +214,6 @@ module Parallel
       rescue Errno::ESRCH
         # some linux systems already automatically killed the children at this point
         # so we just ignore them not being there
-      end
-
-      private
-
-      def trap_interrupt(signal)
-        old = Signal.trap signal, 'IGNORE'
-
-        Signal.trap signal do
-          yield
-          if !old || old == "DEFAULT"
-            raise Interrupt
-          else
-            old.call
-          end
-        end
-
-        old
-      end
-
-      def restore_interrupt(old, signal)
-        Signal.trap signal, old
       end
     end
   end
@@ -557,7 +556,7 @@ module Parallel
       results_mutex = Mutex.new # arrays are not thread-safe
       exception = nil
 
-      UserInterruptHandler.kill_on_ctrl_c(workers.map(&:pid), options) do
+      UserInterruptHandler.kill_on_ctrl_c(workers, options) do
         in_threads(options) do |i|
           worker = workers[i]
           worker.thread = Thread.current

--- a/spec/cases/isolated_interrupt.rb
+++ b/spec/cases/isolated_interrupt.rb
@@ -1,6 +1,11 @@
 # frozen_string_literal: true
 require './spec/cases/helper'
 
+# Queue two items to be processed in a single worker with isolation enabled.
+# Shortly after work begins on the second item, send the process the interrupt signal.
+# The process should terminate nearly immediately, indicating the replacement process
+# was killed rather than completing work on the second item.
+
 parent_pid = Process.pid
 killer_pid = fork do
   sleep 1

--- a/spec/cases/isolated_interrupt.rb
+++ b/spec/cases/isolated_interrupt.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+require './spec/cases/helper'
+
+parent_pid = Process.pid
+killer_pid = fork do
+  sleep 1
+  Process.kill(:INT, parent_pid)
+end
+Process.detach(killer_pid)
+
+Parallel.each([0.1, 5], in_processes: 1, isolation: true) do |sec|
+  sleep sec
+end

--- a/spec/parallel_spec.rb
+++ b/spec/parallel_spec.rb
@@ -146,7 +146,8 @@ describe Parallel do
 
     it "kills replaced workers when handling the interrupt signal" do
       time_taken do
-        ruby("spec/cases/isolated_interrupt.rb 2>&1")
+        result = ruby("spec/cases/isolated_interrupt.rb 2>&1 && echo FIN")
+        result.should_not include("FIN")
       end.should <= 2
     end
 

--- a/spec/parallel_spec.rb
+++ b/spec/parallel_spec.rb
@@ -144,7 +144,13 @@ describe Parallel do
       end.should <= 4
     end
 
-    it "preserves original intrrupts" do
+    it "kills replaced workers when handling the interrupt signal" do
+      time_taken do
+        ruby("spec/cases/isolated_interrupt.rb 2>&1")
+      end.should <= 2
+    end
+
+    it "preserves original interrupts" do
       t = Thread.new { ruby("spec/cases/double_interrupt.rb 2>&1 && echo FIN") }
       sleep 2
       kill_process_with_name("spec/cases/double_interrupt.rb") # simulates Ctrl+c
@@ -154,7 +160,7 @@ describe Parallel do
       result.should include("FIN")
     end
 
-    it "restores original intrrupts" do
+    it "restores original interrupts" do
       ruby("spec/cases/after_interrupt.rb 2>&1").should == "DEFAULT\n"
     end
 


### PR DESCRIPTION
Related issue: https://github.com/grosser/parallel/issues/369

I preserved the existing contract as much as I could, but there's a non-zero risk of breaking code that uses the gem. Given the niche use case and easy work around, I'm not sure the reward outweighs the risk. (Although since parallel just bumped to 2.x, it may be close to an appropriate time for a potentially breaking change.)
