### PR TITLE
Remove stale Darwin hwprefs spec

### DIFF
--- a/spec/parallel_spec.rb
+++ b/spec/parallel_spec.rb
@@ -42,13 +42,6 @@ describe Parallel do
     it "returns a number" do
       (1..999).should include(Parallel.processor_count)
     end
-
-    if RUBY_PLATFORM =~ /darwin10/
-      it 'works if hwprefs in not available' do
-        Parallel.should_receive(:hwprefs_available?).and_return false
-        (1..999).should include(Parallel.processor_count)
-      end
-    end
   end
 
   describe ".physical_processor_count" do


### PR DESCRIPTION
The darwin10 example still stubs `hwprefs_available?`, but `processor_count` no longer calls that helper.

Commit 47253e9 added that fallback for old OS X 10.6 systems.

Commit 50bb18b rewrote processor detection and removed the helper, so this example now covers a dead path rather than supported Ruby 3.3+ behavior.